### PR TITLE
Change bt chams only moving

### DIFF
--- a/src/core/features/backtrack.cpp
+++ b/src/core/features/backtrack.cpp
@@ -13,6 +13,7 @@ void Features::Backtrack::store(CUserCmd *cmd) {
                 if (p->health() > 0 && !p->dormant() && p != Globals::localPlayer && p->team() != Globals::localPlayer->team()) {
                     BacktrackPlayer player;
                     player.playerIndex = i;
+                    player.velocity = p->velocity().Length2D();
                     if (p->getAnythingBones(player.boneMatrix)) {
                         currentTick.players.insert(std::pair<int, BacktrackPlayer>(i, player));
                     }
@@ -53,7 +54,7 @@ void Features::Backtrack::createMove(CUserCmd* cmd) {
                             Vector localPlayerEyePos = Globals::localPlayer->eyePos();
 
                             Vector targetEyePos = Vector(player.second.boneMatrix[8][0][3], player.second.boneMatrix[8][1][3], player.second.boneMatrix[8][2][3]); // 8 is headbone in bonematrix
-                            
+
                             QAngle angleToCurrentPlayer = calcAngle(localPlayerEyePos, targetEyePos);
                             angleToCurrentPlayer -= viewAngles;
                             if (angleToCurrentPlayer.y > 180.f) {

--- a/src/core/features/chams.cpp
+++ b/src/core/features/chams.cpp
@@ -31,7 +31,7 @@ void createMaterials() {
         plasticMaterial = Interfaces::materialSystem->FindMaterial("models/inventory_items/trophy_majors/gloss", 0);
         darudeMaterial = Interfaces::materialSystem->FindMaterial("models/inventory_items/music_kit/darude_01/mp3_detail", 0);
 
-        glowMaterial = createMaterial("glow", "VertexLitGeneric", 
+        glowMaterial = createMaterial("glow", "VertexLitGeneric",
         R"#("VertexLitGeneric" {
             "$additive" "1"
             "$envmap" "models/effects/cube_white"
@@ -41,7 +41,7 @@ void createMaterials() {
             "$alpha" "0.8"
         })#");
 
-        oilMaterial = createMaterial("pearlescent", "VertexLitGeneric", 
+        oilMaterial = createMaterial("pearlescent", "VertexLitGeneric",
         R"#("VertexLitGeneric"
         {
             "$basetexture" "vgui/white_additive"
@@ -108,8 +108,10 @@ void chamPlayer(void* thisptr, void* ctx, const DrawModelState_t &state, const M
                             if (CONFIGBOOL("Visuals>Players>Enemies>Chams>Trail")) {
                                 for (Features::Backtrack::BackTrackTick tick : Features::Backtrack::backtrackTicks) {
                                     if (tick.tickCount % 2 == 0) { // only draw every other tick to reduce lag
-                                        if (tick.players.find(p->index()) != tick.players.end()) {
-                                            cham(thisptr, ctx, state, pInfo, tick.players.at(p->index()).boneMatrix, CONFIGCOL("Visuals>Players>Enemies>Chams>Backtrack Color"), CONFIGINT("Visuals>Players>Enemies>Chams>Backtrack Material"), false);
+                                        if (tick.players.at(p->index()).velocity > 0) {
+                                            if (tick.players.find(p->index()) != tick.players.end()) {
+                                                cham(thisptr, ctx, state, pInfo, tick.players.at(p->index()).boneMatrix, CONFIGCOL("Visuals>Players>Enemies>Chams>Backtrack Color"), CONFIGINT("Visuals>Players>Enemies>Chams>Backtrack Material"), false);
+                                            }
                                         }
                                     }
                                 }
@@ -117,7 +119,9 @@ void chamPlayer(void* thisptr, void* ctx, const DrawModelState_t &state, const M
                             else {
                                 Features::Backtrack::BackTrackTick tick = Features::Backtrack::backtrackTicks.at(Features::Backtrack::backtrackTicks.size()-1);
                                 if (tick.players.find(p->index()) != tick.players.end()) {
-                                    cham(thisptr, ctx, state, pInfo, tick.players.at(p->index()).boneMatrix, CONFIGCOL("Visuals>Players>Enemies>Chams>Backtrack Color"), CONFIGINT("Visuals>Players>Enemies>Chams>Backtrack Material"), false);
+                                    if (tick.players.at(p->index()).velocity > 0) {
+                                        cham(thisptr, ctx, state, pInfo, tick.players.at(p->index()).boneMatrix, CONFIGCOL("Visuals>Players>Enemies>Chams>Backtrack Color"), CONFIGINT("Visuals>Players>Enemies>Chams>Backtrack Material"), false);
+                                    }
                                 }
                             }
                         }
@@ -192,7 +196,7 @@ void Features::Chams::drawModelExecute(void* thisptr, void* ctx, const DrawModel
         else {
             chamWeapon(thisptr, ctx, state, pInfo, pCustomBoneToWorld);
         }
-    } 
+    }
     else if (strstr(modelName, "models/weapons/v_")) {
         chamWeapon(thisptr, ctx, state, pInfo, pCustomBoneToWorld);
     }

--- a/src/core/features/features.hpp
+++ b/src/core/features/features.hpp
@@ -37,6 +37,7 @@ namespace Features {
         struct BacktrackPlayer {
             matrix3x4_t boneMatrix[128];
             int playerIndex;
+            int velocity;
         };
 
         struct BackTrackTick {
@@ -121,7 +122,7 @@ namespace Features {
     }
     namespace RagdollGravity {
         void frameStageNotify(FrameStage frame);
-    } 
+    }
     namespace NoVisualRecoil {
         void frameStageNotify(FrameStage frame);
     }

--- a/src/core/features/legitbot.cpp
+++ b/src/core/features/legitbot.cpp
@@ -9,86 +9,193 @@ void Features::LegitBot::createMove(CUserCmd* cmd) {
         if (weapon) {
             float smoothing = 1.f + (CONFIGINT("Legit>LegitBot>Default>Smoothing")/5.f);
             float FOV = CONFIGINT("Legit>LegitBot>Default>FOV")/10.f;
+
             bool recoilCompensation = CONFIGBOOL("Legit>LegitBot>Default>Recoil Compensation");
             float rcsX = Globals::localPlayer->aimPunch().x * 2 * CONFIGINT("Legit>LegitBot>Default>RCS Amount Y") / 100; // Flipped because it makes more sense in game this way
             float rcsY = Globals::localPlayer->aimPunch().y * 2 * CONFIGINT("Legit>LegitBot>Default>RCS Amount X") / 100;
             float rcsZ = Globals::localPlayer->aimPunch().z * 2;
             QAngle rcsAngle = recoilCompensation ? QAngle(rcsX, rcsY, rcsZ) : QAngle(0, 0, 0);
 
+            bool flashCheck = CONFIGBOOL("Legit>LegitBot>Default>Flash Check");
+            bool jumpCheck = CONFIGBOOL("Legit>LegitBot>Default>Jump Check");
+            bool enemyJumpCheck = CONFIGBOOL("Legit>LegitBot>Default>Enemy Jump Check");
+
+            bool hbHead = CONFIGBOOL("Legit>LegitBot>Default>Head");
+            bool hbChest = CONFIGBOOL("Legit>LegitBot>Default>Chest");
+            bool hbStomach = CONFIGBOOL("Legit>LegitBot>Default>Stomach");
+            bool hbPelvis = CONFIGBOOL("Legit>LegitBot>Default>Pelvis");
+
             if ((std::find(std::begin(pistols), std::end(pistols), weapon->itemIndex()) != std::end(pistols)) && CONFIGBOOL("Legit>LegitBot>Pistol>Override")) {
                 smoothing = 1.f + (CONFIGINT("Legit>LegitBot>Pistol>Smoothing")/5.f);
                 FOV = CONFIGINT("Legit>LegitBot>Pistol>FOV")/10.f;
+
                 recoilCompensation = false;
+
+                flashCheck = CONFIGBOOL("Legit>LegitBot>Pistol>Flash Check");
+                jumpCheck = CONFIGBOOL("Legit>LegitBot>Pistol>Jump Check");
+                enemyJumpCheck = CONFIGBOOL("Legit>LegitBot>Pistol>Enemy Jump Check");
+
+                hbHead = CONFIGBOOL("Legit>LegitBot>Pistol>Head");
+                hbChest = CONFIGBOOL("Legit>LegitBot>Pistol>Chest");
+                hbStomach = CONFIGBOOL("Legit>LegitBot>Pistol>Stomach");
+                hbPelvis = CONFIGBOOL("Legit>LegitBot>Pistol>Pelvis");
             }
             else if ((std::find(std::begin(heavyPistols), std::end(heavyPistols), weapon->itemIndex()) != std::end(heavyPistols)) && CONFIGBOOL("Legit>LegitBot>Heavy Pistol>Override")) {
                 smoothing = 1.f + (CONFIGINT("Legit>LegitBot>Heavy Pistol>Smoothing")/5.f);
                 FOV = CONFIGINT("Legit>LegitBot>Heavy Pistol>FOV")/10.f;
+
                 recoilCompensation = false;
+
+                flashCheck = CONFIGBOOL("Legit>LegitBot>Heavy Pistol>Flash Check");
+                jumpCheck = CONFIGBOOL("Legit>LegitBot>Heavy Pistol>Jump Check");
+                enemyJumpCheck = CONFIGBOOL("Legit>LegitBot>Heavy Pistol>Enemy Jump Check");
+
+                hbHead = CONFIGBOOL("Legit>LegitBot>Heavy Pistol>Head");
+                hbChest = CONFIGBOOL("Legit>LegitBot>Heavy Pistol>Chest");
+                hbStomach = CONFIGBOOL("Legit>LegitBot>Heavy Pistol>Stomach");
+                hbPelvis = CONFIGBOOL("Legit>LegitBot>Heavy Pistol>Pelvis");
             }
             else if ((std::find(std::begin(rifles), std::end(rifles), weapon->itemIndex()) != std::end(rifles)) && CONFIGBOOL("Legit>LegitBot>Rifle>Override")) {
                 smoothing = 1.f + (CONFIGINT("Legit>LegitBot>Rifle>Smoothing")/5.f);
                 FOV = CONFIGINT("Legit>LegitBot>Rifle>FOV")/10.f;
+
                 recoilCompensation = CONFIGINT("Legit>LegitBot>Rifle>Recoil Compensation");
                 rcsX = Globals::localPlayer->aimPunch().x * 2 * CONFIGINT("Legit>LegitBot>Rifle>RCS Amount Y") / 100; // Flipped because it makes more sense in game this way
                 rcsY = Globals::localPlayer->aimPunch().y * 2 * CONFIGINT("Legit>LegitBot>Rifle>RCS Amount X") / 100;
                 rcsAngle = recoilCompensation ? QAngle(rcsX, rcsY, rcsZ) : QAngle(0, 0, 0);
+
+                flashCheck = CONFIGBOOL("Legit>LegitBot>Rifle>Flash Check");
+                jumpCheck = CONFIGBOOL("Legit>LegitBot>Rifle>Jump Check");
+                enemyJumpCheck = CONFIGBOOL("Legit>LegitBot>Rifle>Enemy Jump Check");
+
+                hbHead = CONFIGBOOL("Legit>LegitBot>Rifle>Head");
+                hbChest = CONFIGBOOL("Legit>LegitBot>Rifle>Chest");
+                hbStomach = CONFIGBOOL("Legit>LegitBot>Rifle>Stomach");
+                hbPelvis = CONFIGBOOL("Legit>LegitBot>Rifle>Pelvis");
             }
             else if ((std::find(std::begin(smgs), std::end(smgs), weapon->itemIndex()) != std::end(smgs)) && CONFIGBOOL("Legit>LegitBot>SMG>Override")) {
                 smoothing = 1.f + (CONFIGINT("Legit>LegitBot>SMG>Smoothing")/5.f);
                 FOV = CONFIGINT("Legit>LegitBot>SMG>FOV")/10.f;
+
                 recoilCompensation = CONFIGINT("Legit>LegitBot>SMG>Recoil Compensation");
                 rcsX = Globals::localPlayer->aimPunch().x * 2 * CONFIGINT("Legit>LegitBot>SMG>RCS Amount Y") / 100; // Flipped because it makes more sense in game this way
                 rcsY = Globals::localPlayer->aimPunch().y * 2 * CONFIGINT("Legit>LegitBot>SMG>RCS Amount X") / 100;
                 rcsAngle = recoilCompensation ? QAngle(rcsX, rcsY, rcsZ) : QAngle(0, 0, 0);
+
+                flashCheck = CONFIGBOOL("Legit>LegitBot>SMG>Flash Check");
+                jumpCheck = CONFIGBOOL("Legit>LegitBot>SMG>Jump Check");
+                enemyJumpCheck = CONFIGBOOL("Legit>LegitBot>SMG>Enemy Jump Check");
+
+                hbHead = CONFIGBOOL("Legit>LegitBot>SMG>Head");
+                hbChest = CONFIGBOOL("Legit>LegitBot>SMG>Chest");
+                hbStomach = CONFIGBOOL("Legit>LegitBot>SMG>Stomach");
+                hbPelvis = CONFIGBOOL("Legit>LegitBot>SMG>Pelvis");
             }
             else if ((weapon->itemIndex() == WEAPON_SSG08) && CONFIGBOOL("Legit>LegitBot>Scout>Override")) {
                 smoothing = 1.f + (CONFIGINT("Legit>LegitBot>Scout>Smoothing")/5.f);
                 FOV = CONFIGINT("Legit>LegitBot>Scout>FOV")/10.f;
+
                 recoilCompensation = false;
+
+                flashCheck = CONFIGBOOL("Legit>LegitBot>Scout>Flash Check");
+                jumpCheck = CONFIGBOOL("Legit>LegitBot>Scout>Jump Check");
+                enemyJumpCheck = CONFIGBOOL("Legit>LegitBot>Scout>Enemy Jump Check");
+
+                hbHead = CONFIGBOOL("Legit>LegitBot>Scout>Head");
+                hbChest = CONFIGBOOL("Legit>LegitBot>Scout>Chest");
+                hbStomach = CONFIGBOOL("Legit>LegitBot>Scout>Stomach");
+                hbPelvis = CONFIGBOOL("Legit>LegitBot>Scout>Pelvis");
             }
             else if ((weapon->itemIndex() == WEAPON_AWP) && CONFIGBOOL("Legit>LegitBot>AWP>Override")) {
                 smoothing = 1.f + (CONFIGINT("Legit>LegitBot>AWP>Smoothing")/5.f);
                 FOV = CONFIGINT("Legit>LegitBot>AWP>FOV")/10.f;
+
                 recoilCompensation = false;
+
+                flashCheck = CONFIGBOOL("Legit>LegitBot>AWP>Flash Check");
+                jumpCheck = CONFIGBOOL("Legit>LegitBot>AWP>Jump Check");
+                enemyJumpCheck = CONFIGBOOL("Legit>LegitBot>AWP>Enemy Jump Check");
+
+                hbHead = CONFIGBOOL("Legit>LegitBot>AWP>Head");
+                hbChest = CONFIGBOOL("Legit>LegitBot>AWP>Chest");
+                hbStomach = CONFIGBOOL("Legit>LegitBot>AWP>Stomach");
+                hbPelvis = CONFIGBOOL("Legit>LegitBot>AWP>Pelvis");
             }
             else if ((std::find(std::begin(heavyWeapons), std::end(heavyWeapons), weapon->itemIndex()) != std::end(heavyWeapons)) && CONFIGBOOL("Legit>LegitBot>Heavy>Override")) {
                 smoothing = 1.f + (CONFIGINT("Legit>LegitBot>Heavy>Smoothing")/5.f);
                 FOV = CONFIGINT("Legit>LegitBot>Heavy>FOV")/10.f;
+
                 recoilCompensation = CONFIGINT("Legit>LegitBot>Heavy>Recoil Compensation");
                 rcsX = Globals::localPlayer->aimPunch().x * 2 * CONFIGINT("Legit>LegitBot>Heavy>RCS Amount Y") / 100; // Flipped because it makes more sense in game this way
                 rcsY = Globals::localPlayer->aimPunch().y * 2 * CONFIGINT("Legit>LegitBot>Heavy>RCS Amount X") / 100;
                 rcsAngle = recoilCompensation ? QAngle(rcsX, rcsY, rcsZ) : QAngle(0, 0, 0);
+
+                flashCheck = CONFIGBOOL("Legit>LegitBot>Heavy>Flash Check");
+                jumpCheck = CONFIGBOOL("Legit>LegitBot>Heavy>Jump Check");
+                enemyJumpCheck = CONFIGBOOL("Legit>LegitBot>Heavy>Enemy Jump Check");
+
+                hbHead = CONFIGBOOL("Legit>LegitBot>Heavy>Head");
+                hbChest = CONFIGBOOL("Legit>LegitBot>Heavy>Chest");
+                hbStomach = CONFIGBOOL("Legit>LegitBot>Heavy>Stomach");
+                hbPelvis = CONFIGBOOL("Legit>LegitBot>Heavy>Pelvis");
             }
 
             float closestDelta = FLT_MAX;
-            QAngle angleToClosestPlayer;
+            QAngle angleToClosestBone;
+
+            // TODO: We should switch to using returns instead of many nested if statements at some point
+            //       just incase anyone ever wants to read the code and not have an aneurysm.
 
             // Enumerate over players and get angle to the closest player to crosshair
             for (int i = 1; i < Interfaces::globals->maxClients; i++) {
                 Player* p = (Player*)Interfaces::entityList->GetClientEntity(i);
+                //if (p && p != Globals::localPlayer && (flashCheck && Globals::localPlayer->maxFlashAlpha() >= 60.f) &&
+                        //(jumpCheck && Globals::localPlayer->flags() & (1<<0)) && (enemyJumpCheck && p->flags() & (1<<0))) {
                 if (p && p != Globals::localPlayer) {
                     if (p->health() > 0 && !p->dormant() && p->team() != Globals::localPlayer->team() && p->visible()) {
+
+                        // I know I said I wouldnt use returns, but this just
+                        // is not happening using nested if statements
+
+                        // TODO: There is definately a better way to do a flashed check
+                        if (flashCheck && Globals::localPlayer->flashDuration() > 0.0f)
+                            return;
+
+                        if (jumpCheck && !(Globals::localPlayer->flags() & (1<<0)))
+                            return;
+
+                        if (enemyJumpCheck && !(p->flags() & (1<<0)))
+                            return;
+
                         matrix3x4_t boneMatrix[128];
                         if (p->getAnythingBones(boneMatrix)) {
                             Vector localPlayerEyePos = Globals::localPlayer->eyePos();
+                            std::vector<int> hitboxes = { hbHead ? 8 : 0, hbChest ? 6 : 0, hbStomach ? 5 : 0, hbPelvis ? 3 : 0 };
 
-                            Vector targetEyePos = p->getBonePos(8); // 8 is headbone in bonematrix
+                            studiohdr_t* model = Interfaces::modelInfo->GetStudioModel(p->model());
+                            if (model) {
+                                for (int i : hitboxes) {
+                                    if (i == 0)
+                                        continue;
 
-                            //QAngle angleToCurrentPlayer = calcAngle(localPlayerEyePos, targetEyePos) - cmd->viewangles - (recoilCompensation ? Globals::localPlayer->aimPunch()*2 : QAngle(0, 0, 0));
-                            QAngle angleToCurrentPlayer = calcAngle(localPlayerEyePos, targetEyePos) - cmd->viewangles - rcsAngle;
-                            normalizeAngles(angleToCurrentPlayer);
+                                    Vector targetBonePos = p->getBonePos(i);
 
-                            if (angleToCurrentPlayer.Length() < closestDelta) {
-                                closestDelta = angleToCurrentPlayer.Length();
-                                angleToClosestPlayer = angleToCurrentPlayer;
+                                    QAngle angleToCurrentBone = calcAngle(localPlayerEyePos, targetBonePos) - cmd->viewangles - rcsAngle;
+                                    normalizeAngles(angleToCurrentBone);
+
+                                    if (angleToCurrentBone.Length() < closestDelta) {
+                                        closestDelta = angleToCurrentBone.Length();
+                                        angleToClosestBone = angleToCurrentBone;
+                                    }
+                                }
                             }
                         }
                     }
                 }
             }
             if (closestDelta < FOV) {
-                if (((angleToClosestPlayer) / smoothing).Length() > 0.005f) { // prevent micro-movements
-                    cmd->viewangles += (angleToClosestPlayer) / smoothing;
+                if (((angleToClosestBone) / smoothing).Length() > 0.005f) { // prevent micro-movements
+                    cmd->viewangles += (angleToClosestBone) / smoothing;
                 }
             }
         }

--- a/src/core/features/legitbot.cpp
+++ b/src/core/features/legitbot.cpp
@@ -10,11 +10,10 @@ void Features::LegitBot::createMove(CUserCmd* cmd) {
             float smoothing = 1.f + (CONFIGINT("Legit>LegitBot>Default>Smoothing")/2.5f);
             float FOV = CONFIGINT("Legit>LegitBot>Default>FOV")/10.f;
 
-            bool recoilCompensation = CONFIGBOOL("Legit>LegitBot>Default>Recoil Compensation");
             float rcsX = Globals::localPlayer->aimPunch().x * 2 * CONFIGINT("Legit>LegitBot>Default>RCS Amount Y") / 100; // Flipped because it makes more sense in game this way
             float rcsY = Globals::localPlayer->aimPunch().y * 2 * CONFIGINT("Legit>LegitBot>Default>RCS Amount X") / 100;
             float rcsZ = Globals::localPlayer->aimPunch().z * 2;
-            QAngle rcsAngle = recoilCompensation ? QAngle(rcsX, rcsY, rcsZ) : QAngle(0, 0, 0);
+            QAngle rcsAngle = QAngle(rcsX, rcsY, rcsZ);
 
             bool flashCheck = CONFIGBOOL("Legit>LegitBot>Default>Flash Check");
             bool jumpCheck = CONFIGBOOL("Legit>LegitBot>Default>Jump Check");
@@ -25,11 +24,12 @@ void Features::LegitBot::createMove(CUserCmd* cmd) {
             bool hbStomach = CONFIGBOOL("Legit>LegitBot>Default>Stomach");
             bool hbPelvis = CONFIGBOOL("Legit>LegitBot>Default>Pelvis");
 
+            float reactionTime = CONFIGINT("Legit>LegitBot>Default>Reaction Time");
+            float maxLockTime = CONFIGINT("Legit>LegitBot>Default>Max Lock Time");
+
             if ((std::find(std::begin(pistols), std::end(pistols), weapon->itemIndex()) != std::end(pistols)) && CONFIGBOOL("Legit>LegitBot>Pistol>Override")) {
                 smoothing = 1.f + (CONFIGINT("Legit>LegitBot>Pistol>Smoothing")/2.5f);
                 FOV = CONFIGINT("Legit>LegitBot>Pistol>FOV")/10.f;
-
-                recoilCompensation = false;
 
                 flashCheck = CONFIGBOOL("Legit>LegitBot>Pistol>Flash Check");
                 jumpCheck = CONFIGBOOL("Legit>LegitBot>Pistol>Jump Check");
@@ -44,8 +44,6 @@ void Features::LegitBot::createMove(CUserCmd* cmd) {
                 smoothing = 1.f + (CONFIGINT("Legit>LegitBot>Heavy Pistol>Smoothing")/2.5f);
                 FOV = CONFIGINT("Legit>LegitBot>Heavy Pistol>FOV")/10.f;
 
-                recoilCompensation = false;
-
                 flashCheck = CONFIGBOOL("Legit>LegitBot>Heavy Pistol>Flash Check");
                 jumpCheck = CONFIGBOOL("Legit>LegitBot>Heavy Pistol>Jump Check");
                 enemyJumpCheck = CONFIGBOOL("Legit>LegitBot>Heavy Pistol>Enemy Jump Check");
@@ -59,10 +57,9 @@ void Features::LegitBot::createMove(CUserCmd* cmd) {
                 smoothing = 1.f + (CONFIGINT("Legit>LegitBot>Rifle>Smoothing")/2.5f);
                 FOV = CONFIGINT("Legit>LegitBot>Rifle>FOV")/10.f;
 
-                recoilCompensation = CONFIGINT("Legit>LegitBot>Rifle>Recoil Compensation");
                 rcsX = Globals::localPlayer->aimPunch().x * 2 * CONFIGINT("Legit>LegitBot>Rifle>RCS Amount Y") / 100; // Flipped because it makes more sense in game this way
                 rcsY = Globals::localPlayer->aimPunch().y * 2 * CONFIGINT("Legit>LegitBot>Rifle>RCS Amount X") / 100;
-                rcsAngle = recoilCompensation ? QAngle(rcsX, rcsY, rcsZ) : QAngle(0, 0, 0);
+                rcsAngle = QAngle(rcsX, rcsY, rcsZ);
 
                 flashCheck = CONFIGBOOL("Legit>LegitBot>Rifle>Flash Check");
                 jumpCheck = CONFIGBOOL("Legit>LegitBot>Rifle>Jump Check");
@@ -72,15 +69,17 @@ void Features::LegitBot::createMove(CUserCmd* cmd) {
                 hbChest = CONFIGBOOL("Legit>LegitBot>Rifle>Chest");
                 hbStomach = CONFIGBOOL("Legit>LegitBot>Rifle>Stomach");
                 hbPelvis = CONFIGBOOL("Legit>LegitBot>Rifle>Pelvis");
+
+                reactionTime = CONFIGINT("Legit>LegitBot>Rifle>Reaction Time");
+                maxLockTime = CONFIGINT("Legit>LegitBot>Rifle>Max Lock Time");
             }
             else if ((std::find(std::begin(smgs), std::end(smgs), weapon->itemIndex()) != std::end(smgs)) && CONFIGBOOL("Legit>LegitBot>SMG>Override")) {
                 smoothing = 1.f + (CONFIGINT("Legit>LegitBot>SMG>Smoothing")/2.5f);
                 FOV = CONFIGINT("Legit>LegitBot>SMG>FOV")/10.f;
 
-                recoilCompensation = CONFIGINT("Legit>LegitBot>SMG>Recoil Compensation");
                 rcsX = Globals::localPlayer->aimPunch().x * 2 * CONFIGINT("Legit>LegitBot>SMG>RCS Amount Y") / 100; // Flipped because it makes more sense in game this way
                 rcsY = Globals::localPlayer->aimPunch().y * 2 * CONFIGINT("Legit>LegitBot>SMG>RCS Amount X") / 100;
-                rcsAngle = recoilCompensation ? QAngle(rcsX, rcsY, rcsZ) : QAngle(0, 0, 0);
+                rcsAngle = QAngle(rcsX, rcsY, rcsZ);
 
                 flashCheck = CONFIGBOOL("Legit>LegitBot>SMG>Flash Check");
                 jumpCheck = CONFIGBOOL("Legit>LegitBot>SMG>Jump Check");
@@ -90,12 +89,13 @@ void Features::LegitBot::createMove(CUserCmd* cmd) {
                 hbChest = CONFIGBOOL("Legit>LegitBot>SMG>Chest");
                 hbStomach = CONFIGBOOL("Legit>LegitBot>SMG>Stomach");
                 hbPelvis = CONFIGBOOL("Legit>LegitBot>SMG>Pelvis");
+
+                reactionTime = CONFIGINT("Legit>LegitBot>SMG>Reaction Time");
+                maxLockTime = CONFIGINT("Legit>LegitBot>SMG>Max Lock Time");
             }
             else if ((weapon->itemIndex() == WEAPON_SSG08) && CONFIGBOOL("Legit>LegitBot>Scout>Override")) {
                 smoothing = 1.f + (CONFIGINT("Legit>LegitBot>Scout>Smoothing")/2.5f);
                 FOV = CONFIGINT("Legit>LegitBot>Scout>FOV")/10.f;
-
-                recoilCompensation = false;
 
                 flashCheck = CONFIGBOOL("Legit>LegitBot>Scout>Flash Check");
                 jumpCheck = CONFIGBOOL("Legit>LegitBot>Scout>Jump Check");
@@ -110,8 +110,6 @@ void Features::LegitBot::createMove(CUserCmd* cmd) {
                 smoothing = 1.f + (CONFIGINT("Legit>LegitBot>AWP>Smoothing")/2.5f);
                 FOV = CONFIGINT("Legit>LegitBot>AWP>FOV")/10.f;
 
-                recoilCompensation = false;
-
                 flashCheck = CONFIGBOOL("Legit>LegitBot>AWP>Flash Check");
                 jumpCheck = CONFIGBOOL("Legit>LegitBot>AWP>Jump Check");
                 enemyJumpCheck = CONFIGBOOL("Legit>LegitBot>AWP>Enemy Jump Check");
@@ -125,10 +123,9 @@ void Features::LegitBot::createMove(CUserCmd* cmd) {
                 smoothing = 1.f + (CONFIGINT("Legit>LegitBot>Heavy>Smoothing")/2.5f);
                 FOV = CONFIGINT("Legit>LegitBot>Heavy>FOV")/10.f;
 
-                recoilCompensation = CONFIGINT("Legit>LegitBot>Heavy>Recoil Compensation");
                 rcsX = Globals::localPlayer->aimPunch().x * 2 * CONFIGINT("Legit>LegitBot>Heavy>RCS Amount Y") / 100; // Flipped because it makes more sense in game this way
                 rcsY = Globals::localPlayer->aimPunch().y * 2 * CONFIGINT("Legit>LegitBot>Heavy>RCS Amount X") / 100;
-                rcsAngle = recoilCompensation ? QAngle(rcsX, rcsY, rcsZ) : QAngle(0, 0, 0);
+                rcsAngle = QAngle(rcsX, rcsY, rcsZ);
 
                 flashCheck = CONFIGBOOL("Legit>LegitBot>Heavy>Flash Check");
                 jumpCheck = CONFIGBOOL("Legit>LegitBot>Heavy>Jump Check");
@@ -149,8 +146,6 @@ void Features::LegitBot::createMove(CUserCmd* cmd) {
             // Enumerate over players and get angle to the closest player to crosshair
             for (int i = 1; i < Interfaces::globals->maxClients; i++) {
                 Player* p = (Player*)Interfaces::entityList->GetClientEntity(i);
-                //if (p && p != Globals::localPlayer && (flashCheck && Globals::localPlayer->maxFlashAlpha() >= 60.f) &&
-                        //(jumpCheck && Globals::localPlayer->flags() & (1<<0)) && (enemyJumpCheck && p->flags() & (1<<0))) {
                 if (p && p != Globals::localPlayer) {
                     if (p->health() > 0 && !p->dormant() && p->team() != Globals::localPlayer->team() && p->visible()) {
 
@@ -167,9 +162,24 @@ void Features::LegitBot::createMove(CUserCmd* cmd) {
                         if (enemyJumpCheck && !(p->flags() & (1<<0)))
                             return;
 
+                        // TODO: What the hell am I doing wrong, idk how to use curtime
+                        /*if (reactionTime > 0.f) {
+                            float curTime = Interfaces::globals->curtime;
+                            const float timeToWait = curTime + (reactionTime / 1000.f);
+                            if (curTime < timeToWait)
+                                return;
+                        }
+                        if (maxLockTime > 0.f) {
+                            float curTime = Interfaces::globals->curtime;
+                            const float timeToWait = curTime + (maxLockTime / 1000.f);
+                            if (curTime > maxLockTime)
+                                return;
+                        }*/
+
                         matrix3x4_t boneMatrix[128];
                         if (p->getAnythingBones(boneMatrix)) {
                             Vector localPlayerEyePos = Globals::localPlayer->eyePos();
+
                             std::vector<int> hitboxes = { hbHead ? 8 : 0, hbChest ? 6 : 0, hbStomach ? 5 : 0, hbPelvis ? 3 : 0 };
 
                             studiohdr_t* model = Interfaces::modelInfo->GetStudioModel(p->model());

--- a/src/core/features/legitbot.cpp
+++ b/src/core/features/legitbot.cpp
@@ -3,13 +3,17 @@
 #include <algorithm>
 
 void Features::LegitBot::createMove(CUserCmd* cmd) {
-    if ((Menu::CustomWidgets::isKeyDown(CONFIGINT("Legit>LegitBot>Default>Key")) || CONFIGBOOL("Legit>LegitBot>Default>Always on")) && 
+    if ((Menu::CustomWidgets::isKeyDown(CONFIGINT("Legit>LegitBot>Default>Key")) || CONFIGBOOL("Legit>LegitBot>Default>Always on")) &&
             Interfaces::engine->IsInGame() && Globals::localPlayer && Globals::localPlayer->health() > 0) {
         Weapon *weapon = (Weapon *) Interfaces::entityList->GetClientEntity((uintptr_t)Globals::localPlayer->activeWeapon() & 0xFFF); // GetClientEntityFromHandle is being gay
         if (weapon) {
             float smoothing = 1.f + (CONFIGINT("Legit>LegitBot>Default>Smoothing")/5.f);
             float FOV = CONFIGINT("Legit>LegitBot>Default>FOV")/10.f;
             bool recoilCompensation = CONFIGBOOL("Legit>LegitBot>Default>Recoil Compensation");
+            float rcsX = Globals::localPlayer->aimPunch().x * 2 * CONFIGINT("Legit>LegitBot>Default>RCS Amount Y") / 100; // Flipped because it makes more sense in game this way
+            float rcsY = Globals::localPlayer->aimPunch().y * 2 * CONFIGINT("Legit>LegitBot>Default>RCS Amount X") / 100;
+            float rcsZ = Globals::localPlayer->aimPunch().z * 2;
+            QAngle rcsAngle = recoilCompensation ? QAngle(rcsX, rcsY, rcsZ) : QAngle(0, 0, 0);
 
             if ((std::find(std::begin(pistols), std::end(pistols), weapon->itemIndex()) != std::end(pistols)) && CONFIGBOOL("Legit>LegitBot>Pistol>Override")) {
                 smoothing = 1.f + (CONFIGINT("Legit>LegitBot>Pistol>Smoothing")/5.f);
@@ -25,11 +29,17 @@ void Features::LegitBot::createMove(CUserCmd* cmd) {
                 smoothing = 1.f + (CONFIGINT("Legit>LegitBot>Rifle>Smoothing")/5.f);
                 FOV = CONFIGINT("Legit>LegitBot>Rifle>FOV")/10.f;
                 recoilCompensation = CONFIGINT("Legit>LegitBot>Rifle>Recoil Compensation");
+                rcsX = Globals::localPlayer->aimPunch().x * 2 * CONFIGINT("Legit>LegitBot>Rifle>RCS Amount Y") / 100; // Flipped because it makes more sense in game this way
+                rcsY = Globals::localPlayer->aimPunch().y * 2 * CONFIGINT("Legit>LegitBot>Rifle>RCS Amount X") / 100;
+                rcsAngle = recoilCompensation ? QAngle(rcsX, rcsY, rcsZ) : QAngle(0, 0, 0);
             }
             else if ((std::find(std::begin(smgs), std::end(smgs), weapon->itemIndex()) != std::end(smgs)) && CONFIGBOOL("Legit>LegitBot>SMG>Override")) {
                 smoothing = 1.f + (CONFIGINT("Legit>LegitBot>SMG>Smoothing")/5.f);
                 FOV = CONFIGINT("Legit>LegitBot>SMG>FOV")/10.f;
                 recoilCompensation = CONFIGINT("Legit>LegitBot>SMG>Recoil Compensation");
+                rcsX = Globals::localPlayer->aimPunch().x * 2 * CONFIGINT("Legit>LegitBot>SMG>RCS Amount Y") / 100; // Flipped because it makes more sense in game this way
+                rcsY = Globals::localPlayer->aimPunch().y * 2 * CONFIGINT("Legit>LegitBot>SMG>RCS Amount X") / 100;
+                rcsAngle = recoilCompensation ? QAngle(rcsX, rcsY, rcsZ) : QAngle(0, 0, 0);
             }
             else if ((weapon->itemIndex() == WEAPON_SSG08) && CONFIGBOOL("Legit>LegitBot>Scout>Override")) {
                 smoothing = 1.f + (CONFIGINT("Legit>LegitBot>Scout>Smoothing")/5.f);
@@ -45,6 +55,9 @@ void Features::LegitBot::createMove(CUserCmd* cmd) {
                 smoothing = 1.f + (CONFIGINT("Legit>LegitBot>Heavy>Smoothing")/5.f);
                 FOV = CONFIGINT("Legit>LegitBot>Heavy>FOV")/10.f;
                 recoilCompensation = CONFIGINT("Legit>LegitBot>Heavy>Recoil Compensation");
+                rcsX = Globals::localPlayer->aimPunch().x * 2 * CONFIGINT("Legit>LegitBot>Heavy>RCS Amount Y") / 100; // Flipped because it makes more sense in game this way
+                rcsY = Globals::localPlayer->aimPunch().y * 2 * CONFIGINT("Legit>LegitBot>Heavy>RCS Amount X") / 100;
+                rcsAngle = recoilCompensation ? QAngle(rcsX, rcsY, rcsZ) : QAngle(0, 0, 0);
             }
 
             float closestDelta = FLT_MAX;
@@ -61,7 +74,8 @@ void Features::LegitBot::createMove(CUserCmd* cmd) {
 
                             Vector targetEyePos = p->getBonePos(8); // 8 is headbone in bonematrix
 
-                            QAngle angleToCurrentPlayer = calcAngle(localPlayerEyePos, targetEyePos) - cmd->viewangles - (recoilCompensation ? Globals::localPlayer->aimPunch()*2 : QAngle(0, 0, 0));
+                            //QAngle angleToCurrentPlayer = calcAngle(localPlayerEyePos, targetEyePos) - cmd->viewangles - (recoilCompensation ? Globals::localPlayer->aimPunch()*2 : QAngle(0, 0, 0));
+                            QAngle angleToCurrentPlayer = calcAngle(localPlayerEyePos, targetEyePos) - cmd->viewangles - rcsAngle;
                             normalizeAngles(angleToCurrentPlayer);
 
                             if (angleToCurrentPlayer.Length() < closestDelta) {

--- a/src/core/features/legitbot.cpp
+++ b/src/core/features/legitbot.cpp
@@ -7,7 +7,7 @@ void Features::LegitBot::createMove(CUserCmd* cmd) {
             Interfaces::engine->IsInGame() && Globals::localPlayer && Globals::localPlayer->health() > 0) {
         Weapon *weapon = (Weapon *) Interfaces::entityList->GetClientEntity((uintptr_t)Globals::localPlayer->activeWeapon() & 0xFFF); // GetClientEntityFromHandle is being gay
         if (weapon) {
-            float smoothing = 1.f + (CONFIGINT("Legit>LegitBot>Default>Smoothing")/5.f);
+            float smoothing = 1.f + (CONFIGINT("Legit>LegitBot>Default>Smoothing")/2.5f);
             float FOV = CONFIGINT("Legit>LegitBot>Default>FOV")/10.f;
 
             bool recoilCompensation = CONFIGBOOL("Legit>LegitBot>Default>Recoil Compensation");
@@ -26,7 +26,7 @@ void Features::LegitBot::createMove(CUserCmd* cmd) {
             bool hbPelvis = CONFIGBOOL("Legit>LegitBot>Default>Pelvis");
 
             if ((std::find(std::begin(pistols), std::end(pistols), weapon->itemIndex()) != std::end(pistols)) && CONFIGBOOL("Legit>LegitBot>Pistol>Override")) {
-                smoothing = 1.f + (CONFIGINT("Legit>LegitBot>Pistol>Smoothing")/5.f);
+                smoothing = 1.f + (CONFIGINT("Legit>LegitBot>Pistol>Smoothing")/2.5f);
                 FOV = CONFIGINT("Legit>LegitBot>Pistol>FOV")/10.f;
 
                 recoilCompensation = false;
@@ -41,7 +41,7 @@ void Features::LegitBot::createMove(CUserCmd* cmd) {
                 hbPelvis = CONFIGBOOL("Legit>LegitBot>Pistol>Pelvis");
             }
             else if ((std::find(std::begin(heavyPistols), std::end(heavyPistols), weapon->itemIndex()) != std::end(heavyPistols)) && CONFIGBOOL("Legit>LegitBot>Heavy Pistol>Override")) {
-                smoothing = 1.f + (CONFIGINT("Legit>LegitBot>Heavy Pistol>Smoothing")/5.f);
+                smoothing = 1.f + (CONFIGINT("Legit>LegitBot>Heavy Pistol>Smoothing")/2.5f);
                 FOV = CONFIGINT("Legit>LegitBot>Heavy Pistol>FOV")/10.f;
 
                 recoilCompensation = false;
@@ -56,7 +56,7 @@ void Features::LegitBot::createMove(CUserCmd* cmd) {
                 hbPelvis = CONFIGBOOL("Legit>LegitBot>Heavy Pistol>Pelvis");
             }
             else if ((std::find(std::begin(rifles), std::end(rifles), weapon->itemIndex()) != std::end(rifles)) && CONFIGBOOL("Legit>LegitBot>Rifle>Override")) {
-                smoothing = 1.f + (CONFIGINT("Legit>LegitBot>Rifle>Smoothing")/5.f);
+                smoothing = 1.f + (CONFIGINT("Legit>LegitBot>Rifle>Smoothing")/2.5f);
                 FOV = CONFIGINT("Legit>LegitBot>Rifle>FOV")/10.f;
 
                 recoilCompensation = CONFIGINT("Legit>LegitBot>Rifle>Recoil Compensation");
@@ -74,7 +74,7 @@ void Features::LegitBot::createMove(CUserCmd* cmd) {
                 hbPelvis = CONFIGBOOL("Legit>LegitBot>Rifle>Pelvis");
             }
             else if ((std::find(std::begin(smgs), std::end(smgs), weapon->itemIndex()) != std::end(smgs)) && CONFIGBOOL("Legit>LegitBot>SMG>Override")) {
-                smoothing = 1.f + (CONFIGINT("Legit>LegitBot>SMG>Smoothing")/5.f);
+                smoothing = 1.f + (CONFIGINT("Legit>LegitBot>SMG>Smoothing")/2.5f);
                 FOV = CONFIGINT("Legit>LegitBot>SMG>FOV")/10.f;
 
                 recoilCompensation = CONFIGINT("Legit>LegitBot>SMG>Recoil Compensation");
@@ -92,7 +92,7 @@ void Features::LegitBot::createMove(CUserCmd* cmd) {
                 hbPelvis = CONFIGBOOL("Legit>LegitBot>SMG>Pelvis");
             }
             else if ((weapon->itemIndex() == WEAPON_SSG08) && CONFIGBOOL("Legit>LegitBot>Scout>Override")) {
-                smoothing = 1.f + (CONFIGINT("Legit>LegitBot>Scout>Smoothing")/5.f);
+                smoothing = 1.f + (CONFIGINT("Legit>LegitBot>Scout>Smoothing")/2.5f);
                 FOV = CONFIGINT("Legit>LegitBot>Scout>FOV")/10.f;
 
                 recoilCompensation = false;
@@ -107,7 +107,7 @@ void Features::LegitBot::createMove(CUserCmd* cmd) {
                 hbPelvis = CONFIGBOOL("Legit>LegitBot>Scout>Pelvis");
             }
             else if ((weapon->itemIndex() == WEAPON_AWP) && CONFIGBOOL("Legit>LegitBot>AWP>Override")) {
-                smoothing = 1.f + (CONFIGINT("Legit>LegitBot>AWP>Smoothing")/5.f);
+                smoothing = 1.f + (CONFIGINT("Legit>LegitBot>AWP>Smoothing")/2.5f);
                 FOV = CONFIGINT("Legit>LegitBot>AWP>FOV")/10.f;
 
                 recoilCompensation = false;
@@ -122,7 +122,7 @@ void Features::LegitBot::createMove(CUserCmd* cmd) {
                 hbPelvis = CONFIGBOOL("Legit>LegitBot>AWP>Pelvis");
             }
             else if ((std::find(std::begin(heavyWeapons), std::end(heavyWeapons), weapon->itemIndex()) != std::end(heavyWeapons)) && CONFIGBOOL("Legit>LegitBot>Heavy>Override")) {
-                smoothing = 1.f + (CONFIGINT("Legit>LegitBot>Heavy>Smoothing")/5.f);
+                smoothing = 1.f + (CONFIGINT("Legit>LegitBot>Heavy>Smoothing")/2.5f);
                 FOV = CONFIGINT("Legit>LegitBot>Heavy>FOV")/10.f;
 
                 recoilCompensation = CONFIGINT("Legit>LegitBot>Heavy>Recoil Compensation");

--- a/src/core/menu/config.hpp
+++ b/src/core/menu/config.hpp
@@ -62,53 +62,129 @@ namespace Config {
                     CONFIGITEM("Legit>LegitBot>Default>Always on", false),
                     CONFIGITEM("Legit>LegitBot>Default>FOV", 0),
                     CONFIGITEM("Legit>LegitBot>Default>Smoothing", 0),
+
                     CONFIGITEM("Legit>LegitBot>Default>Recoil Compensation", false),
                     CONFIGITEM("Legit>LegitBot>Default>RCS Amount X", 100),
                     CONFIGITEM("Legit>LegitBot>Default>RCS Amount Y", 100),
+
+                    CONFIGITEM("Legit>LegitBot>Default>Flash Check", false),
+                    CONFIGITEM("Legit>LegitBot>Default>Jump Check", false),
+                    CONFIGITEM("Legit>LegitBot>Default>Enemy Jump Check", false),
+
+                    CONFIGITEM("Legit>LegitBot>Default>Head", false),
+                    CONFIGITEM("Legit>LegitBot>Default>Chest", false),
+                    CONFIGITEM("Legit>LegitBot>Default>Stomach", false),
+                    CONFIGITEM("Legit>LegitBot>Default>Pelvis", false),
                 //}
                 // Pistol {
                     CONFIGITEM("Legit>LegitBot>Pistol>Override", false),
                     CONFIGITEM("Legit>LegitBot>Pistol>FOV", 0),
                     CONFIGITEM("Legit>LegitBot>Pistol>Smoothing", 0),
+
+                    CONFIGITEM("Legit>LegitBot>Pistol>Flash Check", false),
+                    CONFIGITEM("Legit>LegitBot>Pistol>Jump Check", false),
+                    CONFIGITEM("Legit>LegitBot>Pistol>Enemy Jump Check", false),
+
+                    CONFIGITEM("Legit>LegitBot>Pistol>Head", false),
+                    CONFIGITEM("Legit>LegitBot>Pistol>Chest", false),
+                    CONFIGITEM("Legit>LegitBot>Pistol>Stomach", false),
+                    CONFIGITEM("Legit>LegitBot>Pistol>Pelvis", false),
                 //}
                 // Heavy Pistol {
                     CONFIGITEM("Legit>LegitBot>Heavy Pistol>Override", false),
                     CONFIGITEM("Legit>LegitBot>Heavy Pistol>FOV", 0),
                     CONFIGITEM("Legit>LegitBot>Heavy Pistol>Smoothing", 0),
+
+                    CONFIGITEM("Legit>LegitBot>Heavy Pistol>Flash Check", false),
+                    CONFIGITEM("Legit>LegitBot>Heavy Pistol>Jump Check", false),
+                    CONFIGITEM("Legit>LegitBot>Heavy Pistol>Enemy Jump Check", false),
+
+                    CONFIGITEM("Legit>LegitBot>Heavy Pistol>Head", false),
+                    CONFIGITEM("Legit>LegitBot>Heavy Pistol>Chest", false),
+                    CONFIGITEM("Legit>LegitBot>Heavy Pistol>Stomach", false),
+                    CONFIGITEM("Legit>LegitBot>Heavy Pistol>Pelvis", false),
                 //}
                 // Rifle {
                     CONFIGITEM("Legit>LegitBot>Rifle>Override", false),
                     CONFIGITEM("Legit>LegitBot>Rifle>FOV", 0),
                     CONFIGITEM("Legit>LegitBot>Rifle>Smoothing", 0),
+
                     CONFIGITEM("Legit>LegitBot>Rifle>Recoil Compensation", false),
                     CONFIGITEM("Legit>LegitBot>Rifle>RCS Amount X", 100),
                     CONFIGITEM("Legit>LegitBot>Rifle>RCS Amount Y", 100),
+
+                    CONFIGITEM("Legit>LegitBot>Rifle>Flash Check", false),
+                    CONFIGITEM("Legit>LegitBot>Rifle>Jump Check", false),
+                    CONFIGITEM("Legit>LegitBot>Rifle>Enemy Jump Check", false),
+
+                    CONFIGITEM("Legit>LegitBot>Rifle>Head", false),
+                    CONFIGITEM("Legit>LegitBot>Rifle>Chest", false),
+                    CONFIGITEM("Legit>LegitBot>Rifle>Stomach", false),
+                    CONFIGITEM("Legit>LegitBot>Rifle>Pelvis", false),
                 //}
                 // SMG {
                     CONFIGITEM("Legit>LegitBot>SMG>Override", false),
                     CONFIGITEM("Legit>LegitBot>SMG>FOV", 0),
                     CONFIGITEM("Legit>LegitBot>SMG>Smoothing", 0),
+
                     CONFIGITEM("Legit>LegitBot>SMG>Recoil Compensation", false),
                     CONFIGITEM("Legit>LegitBot>SMG>RCS Amount X", 100),
                     CONFIGITEM("Legit>LegitBot>SMG>RCS Amount Y", 100),
+
+                    CONFIGITEM("Legit>LegitBot>SMG>Flash Check", false),
+                    CONFIGITEM("Legit>LegitBot>SMG>Jump Check", false),
+                    CONFIGITEM("Legit>LegitBot>SMG>Enemy Jump Check", false),
+
+                    CONFIGITEM("Legit>LegitBot>SMG>Head", false),
+                    CONFIGITEM("Legit>LegitBot>SMG>Chest", false),
+                    CONFIGITEM("Legit>LegitBot>SMG>Stomach", false),
+                    CONFIGITEM("Legit>LegitBot>SMG>Pelvis", false),
                 //}
                 // Scout {
                     CONFIGITEM("Legit>LegitBot>Scout>Override", false),
                     CONFIGITEM("Legit>LegitBot>Scout>FOV", 0),
                     CONFIGITEM("Legit>LegitBot>Scout>Smoothing", 0),
+
+                    CONFIGITEM("Legit>LegitBot>Scout>Flash Check", false),
+                    CONFIGITEM("Legit>LegitBot>Scout>Jump Check", false),
+                    CONFIGITEM("Legit>LegitBot>Scout>Enemy Jump Check", false),
+
+                    CONFIGITEM("Legit>LegitBot>Scout>Head", false),
+                    CONFIGITEM("Legit>LegitBot>Scout>Chest", false),
+                    CONFIGITEM("Legit>LegitBot>Scout>Stomach", false),
+                    CONFIGITEM("Legit>LegitBot>Scout>Pelvis", false),
                 //}
                 // AWP {
                     CONFIGITEM("Legit>LegitBot>AWP>Override", false),
                     CONFIGITEM("Legit>LegitBot>AWP>FOV", 0),
                     CONFIGITEM("Legit>LegitBot>AWP>Smoothing", 0),
+
+                    CONFIGITEM("Legit>LegitBot>AWP>Flash Check", false),
+                    CONFIGITEM("Legit>LegitBot>AWP>Jump Check", false),
+                    CONFIGITEM("Legit>LegitBot>AWP>Enemy Jump Check", false),
+
+                    CONFIGITEM("Legit>LegitBot>AWP>Head", false),
+                    CONFIGITEM("Legit>LegitBot>AWP>Chest", false),
+                    CONFIGITEM("Legit>LegitBot>AWP>Stomach", false),
+                    CONFIGITEM("Legit>LegitBot>AWP>Pelvis", false),
                 //}
                 // Heavy {
                     CONFIGITEM("Legit>LegitBot>Heavy>Override", false),
                     CONFIGITEM("Legit>LegitBot>Heavy>FOV", 0),
                     CONFIGITEM("Legit>LegitBot>Heavy>Smoothing", 0),
+
                     CONFIGITEM("Legit>LegitBot>Heavy>Recoil Compensation", false),
                     CONFIGITEM("Legit>LegitBot>Heavy>RCS Amount X", 100),
                     CONFIGITEM("Legit>LegitBot>Heavy>RCS Amount Y", 100),
+
+                    CONFIGITEM("Legit>LegitBot>Heavy>Flash Check", false),
+                    CONFIGITEM("Legit>LegitBot>Heavy>Jump Check", false),
+                    CONFIGITEM("Legit>LegitBot>Heavy>Enemy Jump Check", false),
+
+                    CONFIGITEM("Legit>LegitBot>Heavy>Head", false),
+                    CONFIGITEM("Legit>LegitBot>Heavy>Chest", false),
+                    CONFIGITEM("Legit>LegitBot>Heavy>Stomach", false),
+                    CONFIGITEM("Legit>LegitBot>Heavy>Pelvis", false),
                 //}
             // }
 

--- a/src/core/menu/config.hpp
+++ b/src/core/menu/config.hpp
@@ -63,6 +63,8 @@ namespace Config {
                     CONFIGITEM("Legit>LegitBot>Default>FOV", 0),
                     CONFIGITEM("Legit>LegitBot>Default>Smoothing", 0),
                     CONFIGITEM("Legit>LegitBot>Default>Recoil Compensation", false),
+                    CONFIGITEM("Legit>LegitBot>Default>RCS Amount X", 100),
+                    CONFIGITEM("Legit>LegitBot>Default>RCS Amount Y", 100),
                 //}
                 // Pistol {
                     CONFIGITEM("Legit>LegitBot>Pistol>Override", false),
@@ -79,12 +81,16 @@ namespace Config {
                     CONFIGITEM("Legit>LegitBot>Rifle>FOV", 0),
                     CONFIGITEM("Legit>LegitBot>Rifle>Smoothing", 0),
                     CONFIGITEM("Legit>LegitBot>Rifle>Recoil Compensation", false),
+                    CONFIGITEM("Legit>LegitBot>Rifle>RCS Amount X", 100),
+                    CONFIGITEM("Legit>LegitBot>Rifle>RCS Amount Y", 100),
                 //}
                 // SMG {
                     CONFIGITEM("Legit>LegitBot>SMG>Override", false),
                     CONFIGITEM("Legit>LegitBot>SMG>FOV", 0),
                     CONFIGITEM("Legit>LegitBot>SMG>Smoothing", 0),
                     CONFIGITEM("Legit>LegitBot>SMG>Recoil Compensation", false),
+                    CONFIGITEM("Legit>LegitBot>SMG>RCS Amount X", 100),
+                    CONFIGITEM("Legit>LegitBot>SMG>RCS Amount Y", 100),
                 //}
                 // Scout {
                     CONFIGITEM("Legit>LegitBot>Scout>Override", false),
@@ -101,6 +107,8 @@ namespace Config {
                     CONFIGITEM("Legit>LegitBot>Heavy>FOV", 0),
                     CONFIGITEM("Legit>LegitBot>Heavy>Smoothing", 0),
                     CONFIGITEM("Legit>LegitBot>Heavy>Recoil Compensation", false),
+                    CONFIGITEM("Legit>LegitBot>Heavy>RCS Amount X", 100),
+                    CONFIGITEM("Legit>LegitBot>Heavy>RCS Amount Y", 100),
                 //}
             // }
 

--- a/src/core/menu/config.hpp
+++ b/src/core/menu/config.hpp
@@ -75,6 +75,9 @@ namespace Config {
                     CONFIGITEM("Legit>LegitBot>Default>Chest", false),
                     CONFIGITEM("Legit>LegitBot>Default>Stomach", false),
                     CONFIGITEM("Legit>LegitBot>Default>Pelvis", false),
+
+                    CONFIGITEM("Legit>LegitBot>Default>Reaction Time", 0),
+                    CONFIGITEM("Legit>LegitBot>Default>Max Lock Time", 0),
                 //}
                 // Pistol {
                     CONFIGITEM("Legit>LegitBot>Pistol>Override", false),
@@ -121,6 +124,9 @@ namespace Config {
                     CONFIGITEM("Legit>LegitBot>Rifle>Chest", false),
                     CONFIGITEM("Legit>LegitBot>Rifle>Stomach", false),
                     CONFIGITEM("Legit>LegitBot>Rifle>Pelvis", false),
+
+                    CONFIGITEM("Legit>LegitBot>Rifle>Reaction Time", 0),
+                    CONFIGITEM("Legit>LegitBot>Rifle>Max Lock Time", 0),
                 //}
                 // SMG {
                     CONFIGITEM("Legit>LegitBot>SMG>Override", false),
@@ -139,6 +145,9 @@ namespace Config {
                     CONFIGITEM("Legit>LegitBot>SMG>Chest", false),
                     CONFIGITEM("Legit>LegitBot>SMG>Stomach", false),
                     CONFIGITEM("Legit>LegitBot>SMG>Pelvis", false),
+
+                    CONFIGITEM("Legit>LegitBot>SMG>Reaction Time", 0),
+                    CONFIGITEM("Legit>LegitBot>SMG>Max Lock Time", 0),
                 //}
                 // Scout {
                     CONFIGITEM("Legit>LegitBot>Scout>Override", false),

--- a/src/core/menu/tabs/legit.cpp
+++ b/src/core/menu/tabs/legit.cpp
@@ -17,6 +17,14 @@ void Menu::drawLegitTab() {
                 ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
                 ImGui::SliderInt("##Smoothing", &CONFIGINT("Legit>LegitBot>Default>Smoothing"), 0, 100);
                 ImGui::Checkbox("Recoil Compensation", &CONFIGBOOL("Legit>LegitBot>Default>Recoil Compensation"));
+                if (CONFIGBOOL("Legit>LegitBot>Default>Recoil Compensation")) {
+                    ImGui::Text("RCS Amount X");
+                    ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
+                    ImGui::SliderInt("##RCS Amount X", &CONFIGINT("Legit>LegitBot>Default>RCS Amount X"), 0, 100);
+                    ImGui::Text("RCS Amount Y");
+                    ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
+                    ImGui::SliderInt("##RCS Amount Y", &CONFIGINT("Legit>LegitBot>Default>RCS Amount Y"), 0, 100);
+                }
 
                 ImGui::EndTabItem();
             }
@@ -28,7 +36,7 @@ void Menu::drawLegitTab() {
                 ImGui::Text("Smoothing");
                 ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
                 ImGui::SliderInt("##Smoothing", &CONFIGINT("Legit>LegitBot>Pistol>Smoothing"), 0, 100);
-                
+
                 ImGui::EndTabItem();
             }
             if (ImGui::BeginTabItem("Heavy Pistol")) {
@@ -39,7 +47,7 @@ void Menu::drawLegitTab() {
                 ImGui::Text("Smoothing");
                 ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
                 ImGui::SliderInt("##Smoothing", &CONFIGINT("Legit>LegitBot>Heavy Pistol>Smoothing"), 0, 100);
-                
+
                 ImGui::EndTabItem();
             }
             if (ImGui::BeginTabItem("Rifle")) {
@@ -51,7 +59,15 @@ void Menu::drawLegitTab() {
                 ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
                 ImGui::SliderInt("##Smoothing", &CONFIGINT("Legit>LegitBot>Rifle>Smoothing"), 0, 100);
                 ImGui::Checkbox("Recoil Compensation", &CONFIGBOOL("Legit>LegitBot>Rifle>Recoil Compensation"));
-                
+                if (CONFIGBOOL("Legit>LegitBot>Rifle>Recoil Compensation")) {
+                    ImGui::Text("RCS Amount X");
+                    ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
+                    ImGui::SliderInt("##RCS Amount X", &CONFIGINT("Legit>LegitBot>Rifle>RCS Amount X"), 0, 100);
+                    ImGui::Text("RCS Amount Y");
+                    ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
+                    ImGui::SliderInt("##RCS Amount Y", &CONFIGINT("Legit>LegitBot>Rifle>RCS Amount Y"), 0, 100);
+                }
+
                 ImGui::EndTabItem();
             }
             if (ImGui::BeginTabItem("SMG")) {
@@ -63,7 +79,15 @@ void Menu::drawLegitTab() {
                 ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
                 ImGui::SliderInt("##Smoothing", &CONFIGINT("Legit>LegitBot>SMG>Smoothing"), 0, 100);
                 ImGui::Checkbox("Recoil Compensation", &CONFIGBOOL("Legit>LegitBot>SMG>Recoil Compensation"));
-                
+                if (CONFIGBOOL("Legit>LegitBot>SMG>Recoil Compensation")) {
+                    ImGui::Text("RCS Amount X");
+                    ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
+                    ImGui::SliderInt("##RCS Amount X", &CONFIGINT("Legit>LegitBot>SMG>RCS Amount X"), 0, 100);
+                    ImGui::Text("RCS Amount Y");
+                    ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
+                    ImGui::SliderInt("##RCS Amount Y", &CONFIGINT("Legit>LegitBot>SMG>RCS Amount Y"), 0, 100);
+                }
+
                 ImGui::EndTabItem();
             }
             if (ImGui::BeginTabItem("Scout")) {
@@ -74,7 +98,7 @@ void Menu::drawLegitTab() {
                 ImGui::Text("Smoothing");
                 ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
                 ImGui::SliderInt("##Smoothing", &CONFIGINT("Legit>LegitBot>Scout>Smoothing"), 0, 100);
-                
+
                 ImGui::EndTabItem();
             }
             if (ImGui::BeginTabItem("AWP")) {
@@ -85,7 +109,7 @@ void Menu::drawLegitTab() {
                 ImGui::Text("Smoothing");
                 ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
                 ImGui::SliderInt("##Smoothing", &CONFIGINT("Legit>LegitBot>AWP>Smoothing"), 0, 100);
-                
+
                 ImGui::EndTabItem();
             }
             if (ImGui::BeginTabItem("Heavy")) {
@@ -97,7 +121,15 @@ void Menu::drawLegitTab() {
                 ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
                 ImGui::SliderInt("##Smoothing", &CONFIGINT("Legit>LegitBot>Heavy>Smoothing"), 0, 100);
                 ImGui::Checkbox("Recoil Compensation", &CONFIGBOOL("Legit>LegitBot>Heavy>Recoil Compensation"));
-                
+                if (CONFIGBOOL("Legit>LegitBot>Heavy>Recoil Compensation")) {
+                    ImGui::Text("RCS Amount X");
+                    ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
+                    ImGui::SliderInt("##RCS Amount X", &CONFIGINT("Legit>LegitBot>Heavy>RCS Amount X"), 0, 100);
+                    ImGui::Text("RCS Amount Y");
+                    ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
+                    ImGui::SliderInt("##RCS Amount Y", &CONFIGINT("Legit>LegitBot>Heavy>RCS Amount Y"), 0, 100);
+                }
+
                 ImGui::EndTabItem();
             }
         ImGui::EndTabBar();

--- a/src/core/menu/tabs/legit.cpp
+++ b/src/core/menu/tabs/legit.cpp
@@ -1,7 +1,7 @@
 #include "../menu.hpp"
 
 void Menu::drawLegitTab() {
-    ImGui::BeginChild("LegitBot", ImVec2(ImGui::GetWindowContentRegionWidth() * 0.65f, 260), true); {
+    ImGui::BeginChild("LegitBot", ImVec2(ImGui::GetWindowContentRegionWidth() * 0.50f, 430), true); {
         ImGui::Text("LegitBot");
         ImGui::Separator();
         if (ImGui::BeginTabBar("Aim Weapons Tabbar")) {
@@ -17,27 +17,28 @@ void Menu::drawLegitTab() {
                 ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
                 ImGui::SliderInt("##Smoothing", &CONFIGINT("Legit>LegitBot>Default>Smoothing"), 0, 100);
 
-                ImGui::Separator();
-                ImGui::Text("Hitboxes");
-                ImGui::Checkbox("Head", &CONFIGBOOL("Legit>LegitBot>Default>Head"));
-                ImGui::Checkbox("Chest", &CONFIGBOOL("Legit>LegitBot>Default>Chest"));
-                ImGui::Checkbox("Stomach", &CONFIGBOOL("Legit>LegitBot>Default>Stomach"));
-                ImGui::Checkbox("Pelvis", &CONFIGBOOL("Legit>LegitBot>Default>Pelvis"));
-                ImGui::Separator();
+                ImGui::Text("Reaction Time (ms)");
+                ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
+                ImGui::SliderInt("##Reaction Time", &CONFIGINT("Legit>LegitBot>Default>Reaction Time"), 0, 1000);
 
-                ImGui::Checkbox("Recoil Compensation", &CONFIGBOOL("Legit>LegitBot>Default>Recoil Compensation"));
-                if (CONFIGBOOL("Legit>LegitBot>Default>Recoil Compensation")) {
-                    ImGui::Text("RCS Amount X");
-                    ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
-                    ImGui::SliderInt("##RCS Amount X", &CONFIGINT("Legit>LegitBot>Default>RCS Amount X"), 0, 100);
-                    ImGui::Text("RCS Amount Y");
-                    ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
-                    ImGui::SliderInt("##RCS Amount Y", &CONFIGINT("Legit>LegitBot>Default>RCS Amount Y"), 0, 100);
-                }
+                ImGui::Text("Max Lock Time (ms)");
+                ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
+                ImGui::SliderInt("##Max Lock Time", &CONFIGINT("Legit>LegitBot>Default>Max Lock Time"), 0, 5000);
+
+                ImGui::Text("RCS Amount X/Y");
+                ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
+                ImGui::SliderInt("##RCS Amount X", &CONFIGINT("Legit>LegitBot>Default>RCS Amount X"), 0, 100);
+                ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
+                ImGui::SliderInt("##RCS Amount Y", &CONFIGINT("Legit>LegitBot>Default>RCS Amount Y"), 0, 100);
 
                 ImGui::Checkbox("Flash Check", &CONFIGBOOL("Legit>LegitBot>Default>Flash Check"));
                 ImGui::Checkbox("Jump Check", &CONFIGBOOL("Legit>LegitBot>Default>Jump Check"));
                 ImGui::Checkbox("Enemy Jump Check", &CONFIGBOOL("Legit>LegitBot>Default>Enemy Jump Check"));
+
+                ImGui::Checkbox("Head", &CONFIGBOOL("Legit>LegitBot>Default>Head"));
+                ImGui::Checkbox("Chest", &CONFIGBOOL("Legit>LegitBot>Default>Chest"));
+                ImGui::Checkbox("Stomach", &CONFIGBOOL("Legit>LegitBot>Default>Stomach"));
+                ImGui::Checkbox("Pelvis", &CONFIGBOOL("Legit>LegitBot>Default>Pelvis"));
 
                 ImGui::EndTabItem();
             }
@@ -50,17 +51,14 @@ void Menu::drawLegitTab() {
                 ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
                 ImGui::SliderInt("##Smoothing", &CONFIGINT("Legit>LegitBot>Pistol>Smoothing"), 0, 100);
 
-                ImGui::Separator();
-                ImGui::Text("Hitboxes");
+                ImGui::Checkbox("Flash Check", &CONFIGBOOL("Legit>LegitBot>Pistol>Flash Check"));
+                ImGui::Checkbox("Jump Check", &CONFIGBOOL("Legit>LegitBot>Pistol>Jump Check"));
+                ImGui::Checkbox("Enemy Jump Check", &CONFIGBOOL("Legit>LegitBot>Pistol>Enemy Jump Check"));
+
                 ImGui::Checkbox("Head", &CONFIGBOOL("Legit>LegitBot>Pistol>Head"));
                 ImGui::Checkbox("Chest", &CONFIGBOOL("Legit>LegitBot>Pistol>Chest"));
                 ImGui::Checkbox("Stomach", &CONFIGBOOL("Legit>LegitBot>Pistol>Stomach"));
                 ImGui::Checkbox("Pelvis", &CONFIGBOOL("Legit>LegitBot>Pistol>Pelvis"));
-                ImGui::Separator();
-
-                ImGui::Checkbox("Flash Check", &CONFIGBOOL("Legit>LegitBot>Pistol>Flash Check"));
-                ImGui::Checkbox("Jump Check", &CONFIGBOOL("Legit>LegitBot>Pistol>Jump Check"));
-                ImGui::Checkbox("Enemy Jump Check", &CONFIGBOOL("Legit>LegitBot>Pistol>Enemy Jump Check"));
 
                 ImGui::EndTabItem();
             }
@@ -73,17 +71,14 @@ void Menu::drawLegitTab() {
                 ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
                 ImGui::SliderInt("##Smoothing", &CONFIGINT("Legit>LegitBot>Heavy Pistol>Smoothing"), 0, 100);
 
-                ImGui::Separator();
-                ImGui::Text("Hitboxes");
+                ImGui::Checkbox("Flash Check", &CONFIGBOOL("Legit>LegitBot>Heavy Pistol>Flash Check"));
+                ImGui::Checkbox("Jump Check", &CONFIGBOOL("Legit>LegitBot>Heavy Pistol>Jump Check"));
+                ImGui::Checkbox("Enemy Jump Check", &CONFIGBOOL("Legit>LegitBot>Heavy Pistol>Enemy Jump Check"));
+
                 ImGui::Checkbox("Head", &CONFIGBOOL("Legit>LegitBot>Heavy Pistol>Head"));
                 ImGui::Checkbox("Chest", &CONFIGBOOL("Legit>LegitBot>Heavy Pistol>Chest"));
                 ImGui::Checkbox("Stomach", &CONFIGBOOL("Legit>LegitBot>Heavy Pistol>Stomach"));
                 ImGui::Checkbox("Pelvis", &CONFIGBOOL("Legit>LegitBot>Heavy Pistol>Pelvis"));
-                ImGui::Separator();
-
-                ImGui::Checkbox("Flash Check", &CONFIGBOOL("Legit>LegitBot>Heavy Pistol>Flash Check"));
-                ImGui::Checkbox("Jump Check", &CONFIGBOOL("Legit>LegitBot>Heavy Pistol>Jump Check"));
-                ImGui::Checkbox("Enemy Jump Check", &CONFIGBOOL("Legit>LegitBot>Heavy Pistol>Enemy Jump Check"));
 
                 ImGui::EndTabItem();
             }
@@ -96,27 +91,28 @@ void Menu::drawLegitTab() {
                 ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
                 ImGui::SliderInt("##Smoothing", &CONFIGINT("Legit>LegitBot>Rifle>Smoothing"), 0, 100);
 
-                ImGui::Separator();
-                ImGui::Text("Hitboxes");
-                ImGui::Checkbox("Head", &CONFIGBOOL("Legit>LegitBot>Rifle>Head"));
-                ImGui::Checkbox("Chest", &CONFIGBOOL("Legit>LegitBot>Rifle>Chest"));
-                ImGui::Checkbox("Stomach", &CONFIGBOOL("Legit>LegitBot>Rifle>Stomach"));
-                ImGui::Checkbox("Pelvis", &CONFIGBOOL("Legit>LegitBot>Rifle>Pelvis"));
-                ImGui::Separator();
+                ImGui::Text("Reaction Time (ms)");
+                ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
+                ImGui::SliderInt("##Reaction Time", &CONFIGINT("Legit>LegitBot>Rifle>Reaction Time"), 0, 1000);
 
-                ImGui::Checkbox("Recoil Compensation", &CONFIGBOOL("Legit>LegitBot>Rifle>Recoil Compensation"));
-                if (CONFIGBOOL("Legit>LegitBot>Rifle>Recoil Compensation")) {
-                    ImGui::Text("RCS Amount X");
-                    ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
-                    ImGui::SliderInt("##RCS Amount X", &CONFIGINT("Legit>LegitBot>Rifle>RCS Amount X"), 0, 100);
-                    ImGui::Text("RCS Amount Y");
-                    ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
-                    ImGui::SliderInt("##RCS Amount Y", &CONFIGINT("Legit>LegitBot>Rifle>RCS Amount Y"), 0, 100);
-                }
+                ImGui::Text("Max Lock Time (ms)");
+                ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
+                ImGui::SliderInt("##Max Lock Time", &CONFIGINT("Legit>LegitBot>Rifle>Max Lock Time"), 0, 5000);
+
+                ImGui::Text("RCS Amount X/Y");
+                ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
+                ImGui::SliderInt("##RCS Amount X", &CONFIGINT("Legit>LegitBot>Rifle>RCS Amount X"), 0, 100);
+                ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
+                ImGui::SliderInt("##RCS Amount Y", &CONFIGINT("Legit>LegitBot>Rifle>RCS Amount Y"), 0, 100);
 
                 ImGui::Checkbox("Flash Check", &CONFIGBOOL("Legit>LegitBot>Rifle>Flash Check"));
                 ImGui::Checkbox("Jump Check", &CONFIGBOOL("Legit>LegitBot>Rifle>Jump Check"));
                 ImGui::Checkbox("Enemy Jump Check", &CONFIGBOOL("Legit>LegitBot>Rifle>Enemy Jump Check"));
+
+                ImGui::Checkbox("Head", &CONFIGBOOL("Legit>LegitBot>Rifle>Head"));
+                ImGui::Checkbox("Chest", &CONFIGBOOL("Legit>LegitBot>Rifle>Chest"));
+                ImGui::Checkbox("Stomach", &CONFIGBOOL("Legit>LegitBot>Rifle>Stomach"));
+                ImGui::Checkbox("Pelvis", &CONFIGBOOL("Legit>LegitBot>Rifle>Pelvis"));
 
                 ImGui::EndTabItem();
             }
@@ -129,27 +125,27 @@ void Menu::drawLegitTab() {
                 ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
                 ImGui::SliderInt("##Smoothing", &CONFIGINT("Legit>LegitBot>SMG>Smoothing"), 0, 100);
 
-                ImGui::Separator();
-                ImGui::Text("Hitboxes");
-                ImGui::Checkbox("Head", &CONFIGBOOL("Legit>LegitBot>SMG>Head"));
-                ImGui::Checkbox("Chest", &CONFIGBOOL("Legit>LegitBot>SMG>Chest"));
-                ImGui::Checkbox("Stomach", &CONFIGBOOL("Legit>LegitBot>SMG>Stomach"));
-                ImGui::Checkbox("Pelvis", &CONFIGBOOL("Legit>LegitBot>SMG>Pelvis"));
-                ImGui::Separator();
+                ImGui::Text("Reaction Time (ms)");
+                ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
+                ImGui::SliderInt("##Reaction Time", &CONFIGINT("Legit>LegitBot>SMG>Reaction Time"), 0, 1000);
 
-                ImGui::Checkbox("Recoil Compensation", &CONFIGBOOL("Legit>LegitBot>SMG>Recoil Compensation"));
-                if (CONFIGBOOL("Legit>LegitBot>SMG>Recoil Compensation")) {
-                    ImGui::Text("RCS Amount X");
-                    ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
-                    ImGui::SliderInt("##RCS Amount X", &CONFIGINT("Legit>LegitBot>SMG>RCS Amount X"), 0, 100);
-                    ImGui::Text("RCS Amount Y");
-                    ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
-                    ImGui::SliderInt("##RCS Amount Y", &CONFIGINT("Legit>LegitBot>SMG>RCS Amount Y"), 0, 100);
-                }
+                ImGui::Text("Max Lock Time (ms)");
+                ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
+                ImGui::SliderInt("##Max Lock Time", &CONFIGINT("Legit>LegitBot>SMG>Max Lock Time"), 0, 5000);
+
+                ImGui::Text("RCS Amount X/Y");
+                ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
+                ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
+                ImGui::SliderInt("##RCS Amount Y", &CONFIGINT("Legit>LegitBot>SMG>RCS Amount Y"), 0, 100);
 
                 ImGui::Checkbox("Flash Check", &CONFIGBOOL("Legit>LegitBot>SMG>Flash Check"));
                 ImGui::Checkbox("Jump Check", &CONFIGBOOL("Legit>LegitBot>SMG>Jump Check"));
                 ImGui::Checkbox("Enemy Jump Check", &CONFIGBOOL("Legit>LegitBot>SMG>Enemy Jump Check"));
+
+                ImGui::Checkbox("Head", &CONFIGBOOL("Legit>LegitBot>SMG>Head"));
+                ImGui::Checkbox("Chest", &CONFIGBOOL("Legit>LegitBot>SMG>Chest"));
+                ImGui::Checkbox("Stomach", &CONFIGBOOL("Legit>LegitBot>SMG>Stomach"));
+                ImGui::Checkbox("Pelvis", &CONFIGBOOL("Legit>LegitBot>SMG>Pelvis"));
 
                 ImGui::EndTabItem();
             }
@@ -162,17 +158,14 @@ void Menu::drawLegitTab() {
                 ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
                 ImGui::SliderInt("##Smoothing", &CONFIGINT("Legit>LegitBot>Scout>Smoothing"), 0, 100);
 
-                ImGui::Separator();
-                ImGui::Text("Hitboxes");
+                ImGui::Checkbox("Flash Check", &CONFIGBOOL("Legit>LegitBot>Scout>Flash Check"));
+                ImGui::Checkbox("Jump Check", &CONFIGBOOL("Legit>LegitBot>Scout>Jump Check"));
+                ImGui::Checkbox("Enemy Jump Check", &CONFIGBOOL("Legit>LegitBot>Scout>Enemy Jump Check"));
+
                 ImGui::Checkbox("Head", &CONFIGBOOL("Legit>LegitBot>Scout>Head"));
                 ImGui::Checkbox("Chest", &CONFIGBOOL("Legit>LegitBot>Scout>Chest"));
                 ImGui::Checkbox("Stomach", &CONFIGBOOL("Legit>LegitBot>Scout>Stomach"));
                 ImGui::Checkbox("Pelvis", &CONFIGBOOL("Legit>LegitBot>Scout>Pelvis"));
-                ImGui::Separator();
-
-                ImGui::Checkbox("Flash Check", &CONFIGBOOL("Legit>LegitBot>Scout>Flash Check"));
-                ImGui::Checkbox("Jump Check", &CONFIGBOOL("Legit>LegitBot>Scout>Jump Check"));
-                ImGui::Checkbox("Enemy Jump Check", &CONFIGBOOL("Legit>LegitBot>Scout>Enemy Jump Check"));
 
                 ImGui::EndTabItem();
             }
@@ -185,17 +178,14 @@ void Menu::drawLegitTab() {
                 ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
                 ImGui::SliderInt("##Smoothing", &CONFIGINT("Legit>LegitBot>AWP>Smoothing"), 0, 100);
 
-                ImGui::Separator();
-                ImGui::Text("Hitboxes");
+                ImGui::Checkbox("Flash Check", &CONFIGBOOL("Legit>LegitBot>AWP>Flash Check"));
+                ImGui::Checkbox("Jump Check", &CONFIGBOOL("Legit>LegitBot>AWP>Jump Check"));
+                ImGui::Checkbox("Enemy Jump Check", &CONFIGBOOL("Legit>LegitBot>AWP>Enemy Jump Check"));
+
                 ImGui::Checkbox("Head", &CONFIGBOOL("Legit>LegitBot>AWP>Head"));
                 ImGui::Checkbox("Chest", &CONFIGBOOL("Legit>LegitBot>AWP>Chest"));
                 ImGui::Checkbox("Stomach", &CONFIGBOOL("Legit>LegitBot>AWP>Stomach"));
                 ImGui::Checkbox("Pelvis", &CONFIGBOOL("Legit>LegitBot>AWP>Pelvis"));
-                ImGui::Separator();
-
-                ImGui::Checkbox("Flash Check", &CONFIGBOOL("Legit>LegitBot>AWP>Flash Check"));
-                ImGui::Checkbox("Jump Check", &CONFIGBOOL("Legit>LegitBot>AWP>Jump Check"));
-                ImGui::Checkbox("Enemy Jump Check", &CONFIGBOOL("Legit>LegitBot>AWP>Enemy Jump Check"));
 
                 ImGui::EndTabItem();
             }
@@ -208,27 +198,20 @@ void Menu::drawLegitTab() {
                 ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
                 ImGui::SliderInt("##Smoothing", &CONFIGINT("Legit>LegitBot>Heavy>Smoothing"), 0, 100);
 
-                ImGui::Separator();
-                ImGui::Text("Hitboxes");
-                ImGui::Checkbox("Head", &CONFIGBOOL("Legit>LegitBot>Heavy>Head"));
-                ImGui::Checkbox("Chest", &CONFIGBOOL("Legit>LegitBot>Heavy>Chest"));
-                ImGui::Checkbox("Stomach", &CONFIGBOOL("Legit>LegitBot>Heavy>Stomach"));
-                ImGui::Checkbox("Pelvis", &CONFIGBOOL("Legit>LegitBot>Heavy>Pelvis"));
-                ImGui::Separator();
-
-                ImGui::Checkbox("Recoil Compensation", &CONFIGBOOL("Legit>LegitBot>Heavy>Recoil Compensation"));
-                if (CONFIGBOOL("Legit>LegitBot>Heavy>Recoil Compensation")) {
-                    ImGui::Text("RCS Amount X");
-                    ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
-                    ImGui::SliderInt("##RCS Amount X", &CONFIGINT("Legit>LegitBot>Heavy>RCS Amount X"), 0, 100);
-                    ImGui::Text("RCS Amount Y");
-                    ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
-                    ImGui::SliderInt("##RCS Amount Y", &CONFIGINT("Legit>LegitBot>Heavy>RCS Amount Y"), 0, 100);
-                }
+                ImGui::Text("RCS Amount X/Y");
+                ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
+                ImGui::SliderInt("##RCS Amount X", &CONFIGINT("Legit>LegitBot>Heavy>RCS Amount X"), 0, 100);
+                ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
+                ImGui::SliderInt("##RCS Amount Y", &CONFIGINT("Legit>LegitBot>Heavy>RCS Amount Y"), 0, 100);
 
                 ImGui::Checkbox("Flash Check", &CONFIGBOOL("Legit>LegitBot>Heavy>Flash Check"));
                 ImGui::Checkbox("Jump Check", &CONFIGBOOL("Legit>LegitBot>Heavy>Jump Check"));
                 ImGui::Checkbox("Enemy Jump Check", &CONFIGBOOL("Legit>LegitBot>Heavy>Enemy Jump Check"));
+
+                ImGui::Checkbox("Head", &CONFIGBOOL("Legit>LegitBot>Heavy>Head"));
+                ImGui::Checkbox("Chest", &CONFIGBOOL("Legit>LegitBot>Heavy>Chest"));
+                ImGui::Checkbox("Stomach", &CONFIGBOOL("Legit>LegitBot>Heavy>Stomach"));
+                ImGui::Checkbox("Pelvis", &CONFIGBOOL("Legit>LegitBot>Heavy>Pelvis"));
 
                 ImGui::EndTabItem();
             }
@@ -237,7 +220,7 @@ void Menu::drawLegitTab() {
         ImGui::EndChild();
     }
     ImGui::SameLine();
-    ImGui::BeginChild("Triggerbot", ImVec2(0, 260), true); {
+    ImGui::BeginChild("Triggerbot", ImVec2((ImGui::GetWindowContentRegionWidth() * 0.50f) - 7, 430), true); {
         ImGui::Text("Triggerbot");
         ImGui::Separator();
         if (CONFIGBOOL("Legit>Triggerbot>Triggerbot")) {
@@ -258,8 +241,7 @@ void Menu::drawLegitTab() {
 
         ImGui::EndChild();
     }
-    //ImGui::SameLine();
-    ImGui::BeginChild("Backtrack", ImVec2(0, 260), true); {
+    ImGui::BeginChild("Backtrack", ImVec2(ImGui::GetWindowContentRegionWidth(), 140), true); {
         ImGui::Text("Backtrack");
         ImGui::Separator();
         ImGui::Checkbox("Backtrack", &CONFIGBOOL("Legit>Backtrack>Backtrack"));

--- a/src/core/menu/tabs/legit.cpp
+++ b/src/core/menu/tabs/legit.cpp
@@ -16,6 +16,15 @@ void Menu::drawLegitTab() {
                 ImGui::Text("Smoothing");
                 ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
                 ImGui::SliderInt("##Smoothing", &CONFIGINT("Legit>LegitBot>Default>Smoothing"), 0, 100);
+
+                ImGui::Separator();
+                ImGui::Text("Hitboxes");
+                ImGui::Checkbox("Head", &CONFIGBOOL("Legit>LegitBot>Default>Head"));
+                ImGui::Checkbox("Chest", &CONFIGBOOL("Legit>LegitBot>Default>Chest"));
+                ImGui::Checkbox("Stomach", &CONFIGBOOL("Legit>LegitBot>Default>Stomach"));
+                ImGui::Checkbox("Pelvis", &CONFIGBOOL("Legit>LegitBot>Default>Pelvis"));
+                ImGui::Separator();
+
                 ImGui::Checkbox("Recoil Compensation", &CONFIGBOOL("Legit>LegitBot>Default>Recoil Compensation"));
                 if (CONFIGBOOL("Legit>LegitBot>Default>Recoil Compensation")) {
                     ImGui::Text("RCS Amount X");
@@ -30,12 +39,6 @@ void Menu::drawLegitTab() {
                 ImGui::Checkbox("Jump Check", &CONFIGBOOL("Legit>LegitBot>Default>Jump Check"));
                 ImGui::Checkbox("Enemy Jump Check", &CONFIGBOOL("Legit>LegitBot>Default>Enemy Jump Check"));
 
-                ImGui::Text("Hitboxes");
-                ImGui::Checkbox("Head", &CONFIGBOOL("Legit>LegitBot>Default>Head"));
-                ImGui::Checkbox("Chest", &CONFIGBOOL("Legit>LegitBot>Default>Chest"));
-                ImGui::Checkbox("Stomach", &CONFIGBOOL("Legit>LegitBot>Default>Stomach"));
-                ImGui::Checkbox("Pelvis", &CONFIGBOOL("Legit>LegitBot>Default>Pelvis"));
-
                 ImGui::EndTabItem();
             }
             if (ImGui::BeginTabItem("Pistol")) {
@@ -47,15 +50,17 @@ void Menu::drawLegitTab() {
                 ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
                 ImGui::SliderInt("##Smoothing", &CONFIGINT("Legit>LegitBot>Pistol>Smoothing"), 0, 100);
 
-                ImGui::Checkbox("Flash Check", &CONFIGBOOL("Legit>LegitBot>Pistol>Flash Check"));
-                ImGui::Checkbox("Jump Check", &CONFIGBOOL("Legit>LegitBot>Pistol>Jump Check"));
-                ImGui::Checkbox("Enemy Jump Check", &CONFIGBOOL("Legit>LegitBot>Pistol>Enemy Jump Check"));
-
+                ImGui::Separator();
                 ImGui::Text("Hitboxes");
                 ImGui::Checkbox("Head", &CONFIGBOOL("Legit>LegitBot>Pistol>Head"));
                 ImGui::Checkbox("Chest", &CONFIGBOOL("Legit>LegitBot>Pistol>Chest"));
                 ImGui::Checkbox("Stomach", &CONFIGBOOL("Legit>LegitBot>Pistol>Stomach"));
                 ImGui::Checkbox("Pelvis", &CONFIGBOOL("Legit>LegitBot>Pistol>Pelvis"));
+                ImGui::Separator();
+
+                ImGui::Checkbox("Flash Check", &CONFIGBOOL("Legit>LegitBot>Pistol>Flash Check"));
+                ImGui::Checkbox("Jump Check", &CONFIGBOOL("Legit>LegitBot>Pistol>Jump Check"));
+                ImGui::Checkbox("Enemy Jump Check", &CONFIGBOOL("Legit>LegitBot>Pistol>Enemy Jump Check"));
 
                 ImGui::EndTabItem();
             }
@@ -68,15 +73,17 @@ void Menu::drawLegitTab() {
                 ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
                 ImGui::SliderInt("##Smoothing", &CONFIGINT("Legit>LegitBot>Heavy Pistol>Smoothing"), 0, 100);
 
-                ImGui::Checkbox("Flash Check", &CONFIGBOOL("Legit>LegitBot>Heavy Pistol>Flash Check"));
-                ImGui::Checkbox("Jump Check", &CONFIGBOOL("Legit>LegitBot>Heavy Pistol>Jump Check"));
-                ImGui::Checkbox("Enemy Jump Check", &CONFIGBOOL("Legit>LegitBot>Heavy Pistol>Enemy Jump Check"));
-
+                ImGui::Separator();
                 ImGui::Text("Hitboxes");
                 ImGui::Checkbox("Head", &CONFIGBOOL("Legit>LegitBot>Heavy Pistol>Head"));
                 ImGui::Checkbox("Chest", &CONFIGBOOL("Legit>LegitBot>Heavy Pistol>Chest"));
                 ImGui::Checkbox("Stomach", &CONFIGBOOL("Legit>LegitBot>Heavy Pistol>Stomach"));
                 ImGui::Checkbox("Pelvis", &CONFIGBOOL("Legit>LegitBot>Heavy Pistol>Pelvis"));
+                ImGui::Separator();
+
+                ImGui::Checkbox("Flash Check", &CONFIGBOOL("Legit>LegitBot>Heavy Pistol>Flash Check"));
+                ImGui::Checkbox("Jump Check", &CONFIGBOOL("Legit>LegitBot>Heavy Pistol>Jump Check"));
+                ImGui::Checkbox("Enemy Jump Check", &CONFIGBOOL("Legit>LegitBot>Heavy Pistol>Enemy Jump Check"));
 
                 ImGui::EndTabItem();
             }
@@ -88,6 +95,15 @@ void Menu::drawLegitTab() {
                 ImGui::Text("Smoothing");
                 ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
                 ImGui::SliderInt("##Smoothing", &CONFIGINT("Legit>LegitBot>Rifle>Smoothing"), 0, 100);
+
+                ImGui::Separator();
+                ImGui::Text("Hitboxes");
+                ImGui::Checkbox("Head", &CONFIGBOOL("Legit>LegitBot>Rifle>Head"));
+                ImGui::Checkbox("Chest", &CONFIGBOOL("Legit>LegitBot>Rifle>Chest"));
+                ImGui::Checkbox("Stomach", &CONFIGBOOL("Legit>LegitBot>Rifle>Stomach"));
+                ImGui::Checkbox("Pelvis", &CONFIGBOOL("Legit>LegitBot>Rifle>Pelvis"));
+                ImGui::Separator();
+
                 ImGui::Checkbox("Recoil Compensation", &CONFIGBOOL("Legit>LegitBot>Rifle>Recoil Compensation"));
                 if (CONFIGBOOL("Legit>LegitBot>Rifle>Recoil Compensation")) {
                     ImGui::Text("RCS Amount X");
@@ -102,12 +118,6 @@ void Menu::drawLegitTab() {
                 ImGui::Checkbox("Jump Check", &CONFIGBOOL("Legit>LegitBot>Rifle>Jump Check"));
                 ImGui::Checkbox("Enemy Jump Check", &CONFIGBOOL("Legit>LegitBot>Rifle>Enemy Jump Check"));
 
-                ImGui::Text("Hitboxes");
-                ImGui::Checkbox("Head", &CONFIGBOOL("Legit>LegitBot>Rifle>Head"));
-                ImGui::Checkbox("Chest", &CONFIGBOOL("Legit>LegitBot>Rifle>Chest"));
-                ImGui::Checkbox("Stomach", &CONFIGBOOL("Legit>LegitBot>Rifle>Stomach"));
-                ImGui::Checkbox("Pelvis", &CONFIGBOOL("Legit>LegitBot>Rifle>Pelvis"));
-
                 ImGui::EndTabItem();
             }
             if (ImGui::BeginTabItem("SMG")) {
@@ -118,6 +128,15 @@ void Menu::drawLegitTab() {
                 ImGui::Text("Smoothing");
                 ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
                 ImGui::SliderInt("##Smoothing", &CONFIGINT("Legit>LegitBot>SMG>Smoothing"), 0, 100);
+
+                ImGui::Separator();
+                ImGui::Text("Hitboxes");
+                ImGui::Checkbox("Head", &CONFIGBOOL("Legit>LegitBot>SMG>Head"));
+                ImGui::Checkbox("Chest", &CONFIGBOOL("Legit>LegitBot>SMG>Chest"));
+                ImGui::Checkbox("Stomach", &CONFIGBOOL("Legit>LegitBot>SMG>Stomach"));
+                ImGui::Checkbox("Pelvis", &CONFIGBOOL("Legit>LegitBot>SMG>Pelvis"));
+                ImGui::Separator();
+
                 ImGui::Checkbox("Recoil Compensation", &CONFIGBOOL("Legit>LegitBot>SMG>Recoil Compensation"));
                 if (CONFIGBOOL("Legit>LegitBot>SMG>Recoil Compensation")) {
                     ImGui::Text("RCS Amount X");
@@ -132,12 +151,6 @@ void Menu::drawLegitTab() {
                 ImGui::Checkbox("Jump Check", &CONFIGBOOL("Legit>LegitBot>SMG>Jump Check"));
                 ImGui::Checkbox("Enemy Jump Check", &CONFIGBOOL("Legit>LegitBot>SMG>Enemy Jump Check"));
 
-                ImGui::Text("Hitboxes");
-                ImGui::Checkbox("Head", &CONFIGBOOL("Legit>LegitBot>SMG>Head"));
-                ImGui::Checkbox("Chest", &CONFIGBOOL("Legit>LegitBot>SMG>Chest"));
-                ImGui::Checkbox("Stomach", &CONFIGBOOL("Legit>LegitBot>SMG>Stomach"));
-                ImGui::Checkbox("Pelvis", &CONFIGBOOL("Legit>LegitBot>SMG>Pelvis"));
-
                 ImGui::EndTabItem();
             }
             if (ImGui::BeginTabItem("Scout")) {
@@ -149,15 +162,17 @@ void Menu::drawLegitTab() {
                 ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
                 ImGui::SliderInt("##Smoothing", &CONFIGINT("Legit>LegitBot>Scout>Smoothing"), 0, 100);
 
-                ImGui::Checkbox("Flash Check", &CONFIGBOOL("Legit>LegitBot>Scout>Flash Check"));
-                ImGui::Checkbox("Jump Check", &CONFIGBOOL("Legit>LegitBot>Scout>Jump Check"));
-                ImGui::Checkbox("Enemy Jump Check", &CONFIGBOOL("Legit>LegitBot>Scout>Enemy Jump Check"));
-
+                ImGui::Separator();
                 ImGui::Text("Hitboxes");
                 ImGui::Checkbox("Head", &CONFIGBOOL("Legit>LegitBot>Scout>Head"));
                 ImGui::Checkbox("Chest", &CONFIGBOOL("Legit>LegitBot>Scout>Chest"));
                 ImGui::Checkbox("Stomach", &CONFIGBOOL("Legit>LegitBot>Scout>Stomach"));
                 ImGui::Checkbox("Pelvis", &CONFIGBOOL("Legit>LegitBot>Scout>Pelvis"));
+                ImGui::Separator();
+
+                ImGui::Checkbox("Flash Check", &CONFIGBOOL("Legit>LegitBot>Scout>Flash Check"));
+                ImGui::Checkbox("Jump Check", &CONFIGBOOL("Legit>LegitBot>Scout>Jump Check"));
+                ImGui::Checkbox("Enemy Jump Check", &CONFIGBOOL("Legit>LegitBot>Scout>Enemy Jump Check"));
 
                 ImGui::EndTabItem();
             }
@@ -170,15 +185,17 @@ void Menu::drawLegitTab() {
                 ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
                 ImGui::SliderInt("##Smoothing", &CONFIGINT("Legit>LegitBot>AWP>Smoothing"), 0, 100);
 
-                ImGui::Checkbox("Flash Check", &CONFIGBOOL("Legit>LegitBot>AWP>Flash Check"));
-                ImGui::Checkbox("Jump Check", &CONFIGBOOL("Legit>LegitBot>AWP>Jump Check"));
-                ImGui::Checkbox("Enemy Jump Check", &CONFIGBOOL("Legit>LegitBot>AWP>Enemy Jump Check"));
-
+                ImGui::Separator();
                 ImGui::Text("Hitboxes");
                 ImGui::Checkbox("Head", &CONFIGBOOL("Legit>LegitBot>AWP>Head"));
                 ImGui::Checkbox("Chest", &CONFIGBOOL("Legit>LegitBot>AWP>Chest"));
                 ImGui::Checkbox("Stomach", &CONFIGBOOL("Legit>LegitBot>AWP>Stomach"));
                 ImGui::Checkbox("Pelvis", &CONFIGBOOL("Legit>LegitBot>AWP>Pelvis"));
+                ImGui::Separator();
+
+                ImGui::Checkbox("Flash Check", &CONFIGBOOL("Legit>LegitBot>AWP>Flash Check"));
+                ImGui::Checkbox("Jump Check", &CONFIGBOOL("Legit>LegitBot>AWP>Jump Check"));
+                ImGui::Checkbox("Enemy Jump Check", &CONFIGBOOL("Legit>LegitBot>AWP>Enemy Jump Check"));
 
                 ImGui::EndTabItem();
             }
@@ -190,6 +207,15 @@ void Menu::drawLegitTab() {
                 ImGui::Text("Smoothing");
                 ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
                 ImGui::SliderInt("##Smoothing", &CONFIGINT("Legit>LegitBot>Heavy>Smoothing"), 0, 100);
+
+                ImGui::Separator();
+                ImGui::Text("Hitboxes");
+                ImGui::Checkbox("Head", &CONFIGBOOL("Legit>LegitBot>Heavy>Head"));
+                ImGui::Checkbox("Chest", &CONFIGBOOL("Legit>LegitBot>Heavy>Chest"));
+                ImGui::Checkbox("Stomach", &CONFIGBOOL("Legit>LegitBot>Heavy>Stomach"));
+                ImGui::Checkbox("Pelvis", &CONFIGBOOL("Legit>LegitBot>Heavy>Pelvis"));
+                ImGui::Separator();
+
                 ImGui::Checkbox("Recoil Compensation", &CONFIGBOOL("Legit>LegitBot>Heavy>Recoil Compensation"));
                 if (CONFIGBOOL("Legit>LegitBot>Heavy>Recoil Compensation")) {
                     ImGui::Text("RCS Amount X");
@@ -203,12 +229,6 @@ void Menu::drawLegitTab() {
                 ImGui::Checkbox("Flash Check", &CONFIGBOOL("Legit>LegitBot>Heavy>Flash Check"));
                 ImGui::Checkbox("Jump Check", &CONFIGBOOL("Legit>LegitBot>Heavy>Jump Check"));
                 ImGui::Checkbox("Enemy Jump Check", &CONFIGBOOL("Legit>LegitBot>Heavy>Enemy Jump Check"));
-
-                ImGui::Text("Hitboxes");
-                ImGui::Checkbox("Head", &CONFIGBOOL("Legit>LegitBot>Heavy>Head"));
-                ImGui::Checkbox("Chest", &CONFIGBOOL("Legit>LegitBot>Heavy>Chest"));
-                ImGui::Checkbox("Stomach", &CONFIGBOOL("Legit>LegitBot>Heavy>Stomach"));
-                ImGui::Checkbox("Pelvis", &CONFIGBOOL("Legit>LegitBot>Heavy>Pelvis"));
 
                 ImGui::EndTabItem();
             }

--- a/src/core/menu/tabs/legit.cpp
+++ b/src/core/menu/tabs/legit.cpp
@@ -26,6 +26,16 @@ void Menu::drawLegitTab() {
                     ImGui::SliderInt("##RCS Amount Y", &CONFIGINT("Legit>LegitBot>Default>RCS Amount Y"), 0, 100);
                 }
 
+                ImGui::Checkbox("Flash Check", &CONFIGBOOL("Legit>LegitBot>Default>Flash Check"));
+                ImGui::Checkbox("Jump Check", &CONFIGBOOL("Legit>LegitBot>Default>Jump Check"));
+                ImGui::Checkbox("Enemy Jump Check", &CONFIGBOOL("Legit>LegitBot>Default>Enemy Jump Check"));
+
+                ImGui::Text("Hitboxes");
+                ImGui::Checkbox("Head", &CONFIGBOOL("Legit>LegitBot>Default>Head"));
+                ImGui::Checkbox("Chest", &CONFIGBOOL("Legit>LegitBot>Default>Chest"));
+                ImGui::Checkbox("Stomach", &CONFIGBOOL("Legit>LegitBot>Default>Stomach"));
+                ImGui::Checkbox("Pelvis", &CONFIGBOOL("Legit>LegitBot>Default>Pelvis"));
+
                 ImGui::EndTabItem();
             }
             if (ImGui::BeginTabItem("Pistol")) {
@@ -37,6 +47,16 @@ void Menu::drawLegitTab() {
                 ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
                 ImGui::SliderInt("##Smoothing", &CONFIGINT("Legit>LegitBot>Pistol>Smoothing"), 0, 100);
 
+                ImGui::Checkbox("Flash Check", &CONFIGBOOL("Legit>LegitBot>Pistol>Flash Check"));
+                ImGui::Checkbox("Jump Check", &CONFIGBOOL("Legit>LegitBot>Pistol>Jump Check"));
+                ImGui::Checkbox("Enemy Jump Check", &CONFIGBOOL("Legit>LegitBot>Pistol>Enemy Jump Check"));
+
+                ImGui::Text("Hitboxes");
+                ImGui::Checkbox("Head", &CONFIGBOOL("Legit>LegitBot>Pistol>Head"));
+                ImGui::Checkbox("Chest", &CONFIGBOOL("Legit>LegitBot>Pistol>Chest"));
+                ImGui::Checkbox("Stomach", &CONFIGBOOL("Legit>LegitBot>Pistol>Stomach"));
+                ImGui::Checkbox("Pelvis", &CONFIGBOOL("Legit>LegitBot>Pistol>Pelvis"));
+
                 ImGui::EndTabItem();
             }
             if (ImGui::BeginTabItem("Heavy Pistol")) {
@@ -47,6 +67,16 @@ void Menu::drawLegitTab() {
                 ImGui::Text("Smoothing");
                 ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
                 ImGui::SliderInt("##Smoothing", &CONFIGINT("Legit>LegitBot>Heavy Pistol>Smoothing"), 0, 100);
+
+                ImGui::Checkbox("Flash Check", &CONFIGBOOL("Legit>LegitBot>Heavy Pistol>Flash Check"));
+                ImGui::Checkbox("Jump Check", &CONFIGBOOL("Legit>LegitBot>Heavy Pistol>Jump Check"));
+                ImGui::Checkbox("Enemy Jump Check", &CONFIGBOOL("Legit>LegitBot>Heavy Pistol>Enemy Jump Check"));
+
+                ImGui::Text("Hitboxes");
+                ImGui::Checkbox("Head", &CONFIGBOOL("Legit>LegitBot>Heavy Pistol>Head"));
+                ImGui::Checkbox("Chest", &CONFIGBOOL("Legit>LegitBot>Heavy Pistol>Chest"));
+                ImGui::Checkbox("Stomach", &CONFIGBOOL("Legit>LegitBot>Heavy Pistol>Stomach"));
+                ImGui::Checkbox("Pelvis", &CONFIGBOOL("Legit>LegitBot>Heavy Pistol>Pelvis"));
 
                 ImGui::EndTabItem();
             }
@@ -68,6 +98,16 @@ void Menu::drawLegitTab() {
                     ImGui::SliderInt("##RCS Amount Y", &CONFIGINT("Legit>LegitBot>Rifle>RCS Amount Y"), 0, 100);
                 }
 
+                ImGui::Checkbox("Flash Check", &CONFIGBOOL("Legit>LegitBot>Rifle>Flash Check"));
+                ImGui::Checkbox("Jump Check", &CONFIGBOOL("Legit>LegitBot>Rifle>Jump Check"));
+                ImGui::Checkbox("Enemy Jump Check", &CONFIGBOOL("Legit>LegitBot>Rifle>Enemy Jump Check"));
+
+                ImGui::Text("Hitboxes");
+                ImGui::Checkbox("Head", &CONFIGBOOL("Legit>LegitBot>Rifle>Head"));
+                ImGui::Checkbox("Chest", &CONFIGBOOL("Legit>LegitBot>Rifle>Chest"));
+                ImGui::Checkbox("Stomach", &CONFIGBOOL("Legit>LegitBot>Rifle>Stomach"));
+                ImGui::Checkbox("Pelvis", &CONFIGBOOL("Legit>LegitBot>Rifle>Pelvis"));
+
                 ImGui::EndTabItem();
             }
             if (ImGui::BeginTabItem("SMG")) {
@@ -88,6 +128,16 @@ void Menu::drawLegitTab() {
                     ImGui::SliderInt("##RCS Amount Y", &CONFIGINT("Legit>LegitBot>SMG>RCS Amount Y"), 0, 100);
                 }
 
+                ImGui::Checkbox("Flash Check", &CONFIGBOOL("Legit>LegitBot>SMG>Flash Check"));
+                ImGui::Checkbox("Jump Check", &CONFIGBOOL("Legit>LegitBot>SMG>Jump Check"));
+                ImGui::Checkbox("Enemy Jump Check", &CONFIGBOOL("Legit>LegitBot>SMG>Enemy Jump Check"));
+
+                ImGui::Text("Hitboxes");
+                ImGui::Checkbox("Head", &CONFIGBOOL("Legit>LegitBot>SMG>Head"));
+                ImGui::Checkbox("Chest", &CONFIGBOOL("Legit>LegitBot>SMG>Chest"));
+                ImGui::Checkbox("Stomach", &CONFIGBOOL("Legit>LegitBot>SMG>Stomach"));
+                ImGui::Checkbox("Pelvis", &CONFIGBOOL("Legit>LegitBot>SMG>Pelvis"));
+
                 ImGui::EndTabItem();
             }
             if (ImGui::BeginTabItem("Scout")) {
@@ -99,6 +149,16 @@ void Menu::drawLegitTab() {
                 ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
                 ImGui::SliderInt("##Smoothing", &CONFIGINT("Legit>LegitBot>Scout>Smoothing"), 0, 100);
 
+                ImGui::Checkbox("Flash Check", &CONFIGBOOL("Legit>LegitBot>Scout>Flash Check"));
+                ImGui::Checkbox("Jump Check", &CONFIGBOOL("Legit>LegitBot>Scout>Jump Check"));
+                ImGui::Checkbox("Enemy Jump Check", &CONFIGBOOL("Legit>LegitBot>Scout>Enemy Jump Check"));
+
+                ImGui::Text("Hitboxes");
+                ImGui::Checkbox("Head", &CONFIGBOOL("Legit>LegitBot>Scout>Head"));
+                ImGui::Checkbox("Chest", &CONFIGBOOL("Legit>LegitBot>Scout>Chest"));
+                ImGui::Checkbox("Stomach", &CONFIGBOOL("Legit>LegitBot>Scout>Stomach"));
+                ImGui::Checkbox("Pelvis", &CONFIGBOOL("Legit>LegitBot>Scout>Pelvis"));
+
                 ImGui::EndTabItem();
             }
             if (ImGui::BeginTabItem("AWP")) {
@@ -109,6 +169,16 @@ void Menu::drawLegitTab() {
                 ImGui::Text("Smoothing");
                 ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
                 ImGui::SliderInt("##Smoothing", &CONFIGINT("Legit>LegitBot>AWP>Smoothing"), 0, 100);
+
+                ImGui::Checkbox("Flash Check", &CONFIGBOOL("Legit>LegitBot>AWP>Flash Check"));
+                ImGui::Checkbox("Jump Check", &CONFIGBOOL("Legit>LegitBot>AWP>Jump Check"));
+                ImGui::Checkbox("Enemy Jump Check", &CONFIGBOOL("Legit>LegitBot>AWP>Enemy Jump Check"));
+
+                ImGui::Text("Hitboxes");
+                ImGui::Checkbox("Head", &CONFIGBOOL("Legit>LegitBot>AWP>Head"));
+                ImGui::Checkbox("Chest", &CONFIGBOOL("Legit>LegitBot>AWP>Chest"));
+                ImGui::Checkbox("Stomach", &CONFIGBOOL("Legit>LegitBot>AWP>Stomach"));
+                ImGui::Checkbox("Pelvis", &CONFIGBOOL("Legit>LegitBot>AWP>Pelvis"));
 
                 ImGui::EndTabItem();
             }
@@ -129,6 +199,16 @@ void Menu::drawLegitTab() {
                     ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
                     ImGui::SliderInt("##RCS Amount Y", &CONFIGINT("Legit>LegitBot>Heavy>RCS Amount Y"), 0, 100);
                 }
+
+                ImGui::Checkbox("Flash Check", &CONFIGBOOL("Legit>LegitBot>Heavy>Flash Check"));
+                ImGui::Checkbox("Jump Check", &CONFIGBOOL("Legit>LegitBot>Heavy>Jump Check"));
+                ImGui::Checkbox("Enemy Jump Check", &CONFIGBOOL("Legit>LegitBot>Heavy>Enemy Jump Check"));
+
+                ImGui::Text("Hitboxes");
+                ImGui::Checkbox("Head", &CONFIGBOOL("Legit>LegitBot>Heavy>Head"));
+                ImGui::Checkbox("Chest", &CONFIGBOOL("Legit>LegitBot>Heavy>Chest"));
+                ImGui::Checkbox("Stomach", &CONFIGBOOL("Legit>LegitBot>Heavy>Stomach"));
+                ImGui::Checkbox("Pelvis", &CONFIGBOOL("Legit>LegitBot>Heavy>Pelvis"));
 
                 ImGui::EndTabItem();
             }
@@ -158,6 +238,7 @@ void Menu::drawLegitTab() {
 
         ImGui::EndChild();
     }
+    //ImGui::SameLine();
     ImGui::BeginChild("Backtrack", ImVec2(0, 260), true); {
         ImGui::Text("Backtrack");
         ImGui::Separator();

--- a/src/sdk/classes/entity.hpp
+++ b/src/sdk/classes/entity.hpp
@@ -59,7 +59,7 @@ public:
 		typedef const Vector& (*Fn)(void*);
 		return getVirtualFunc<Fn>(this, 12)(this);
 	}
-	
+
 	bool isPlayer() {
 		typedef bool (*Fn)(void*);
 		return getVirtualFunc<Fn>(this, 157)(this);
@@ -87,6 +87,7 @@ public:
 	NETVAR("DT_CSPlayer", "m_flLowerBodyYawTarget", lbyTarget, float);
 	NETVAR("DT_CSPlayer", "m_bIsScoped", scoped, bool);
 	NETVAR("DT_BasePlayer", "deadflag", deadflag, bool);
+    NETVAR("DT_CSPlayer", "m_flFlashDuration", flashDuration, float);
 	NETVAR("DT_CSPlayer", "m_flFlashMaxAlpha", maxFlashAlpha, float);
 	NETVAR("DT_CSPlayer", "m_bHasHelmet", helmet, bool);
 	NETVAR("DT_CSPlayer", "m_ArmorValue", armor, int);
@@ -137,7 +138,7 @@ public:
 		typedef float (*Fn)(void*);
 		return getVirtualFunc<Fn>(this, 520)(this);
 	}
-	
+
 	float GetInaccuracy() {
 		typedef float (*Fn)(void*);
 		return getVirtualFunc<Fn>(this, 550)(this);
@@ -156,4 +157,3 @@ public:
 	NETVAR("DT_EnvTonemapController", "m_flCustomAutoExposureMin", exposureMin, float);
 	NETVAR("DT_EnvTonemapController", "m_flCustomAutoExposureMax", exposureMax, float);
 };
-

--- a/src/sdk/netvars.hpp
+++ b/src/sdk/netvars.hpp
@@ -25,6 +25,7 @@ namespace Netvar {
         {std::make_pair("DT_BasePlayer", "m_vecViewOffset[0]"), 0},
         {std::make_pair("DT_CSPlayer", "m_angEyeAngles[0]"), 0},
         {std::make_pair("DT_CSPlayer", "m_flLowerBodyYawTarget"), 0},
+        {std::make_pair("DT_CSPlayer", "m_flFlashDuration"), 0},
         {std::make_pair("DT_CSPlayer", "m_flFlashMaxAlpha"), 0},
         {std::make_pair("DT_CSPlayer", "m_bIsScoped"), 0},
         {std::make_pair("DT_BasePlayer", "deadflag"), 0},


### PR DESCRIPTION
Only render backtrack chams if the tick being rendered is moving. It's easier on the eyes.