### PR TITLE
Fix bt chams standing render

### DIFF
--- a/src/core/features/backtrack.cpp
+++ b/src/core/features/backtrack.cpp
@@ -13,6 +13,9 @@ void Features::Backtrack::store(CUserCmd *cmd) {
                 if (p->health() > 0 && !p->dormant() && p != Globals::localPlayer && p->team() != Globals::localPlayer->team()) {
                     BacktrackPlayer player;
                     player.playerIndex = i;
+                    player.playerFlags = p->flags();
+                    player.playerVelocity = p->velocity().Length2D();
+                    player.playerHeadPos = p->getBonePos(8);
                     if (p->getAnythingBones(player.boneMatrix)) {
                         currentTick.players.insert(std::pair<int, BacktrackPlayer>(i, player));
                     }
@@ -53,7 +56,7 @@ void Features::Backtrack::createMove(CUserCmd* cmd) {
                             Vector localPlayerEyePos = Globals::localPlayer->eyePos();
 
                             Vector targetEyePos = Vector(player.second.boneMatrix[8][0][3], player.second.boneMatrix[8][1][3], player.second.boneMatrix[8][2][3]); // 8 is headbone in bonematrix
-                            
+
                             QAngle angleToCurrentPlayer = calcAngle(localPlayerEyePos, targetEyePos);
                             angleToCurrentPlayer -= viewAngles;
                             if (angleToCurrentPlayer.y > 180.f) {

--- a/src/core/features/chams.cpp
+++ b/src/core/features/chams.cpp
@@ -31,7 +31,7 @@ void createMaterials() {
         plasticMaterial = Interfaces::materialSystem->FindMaterial("models/inventory_items/trophy_majors/gloss", 0);
         darudeMaterial = Interfaces::materialSystem->FindMaterial("models/inventory_items/music_kit/darude_01/mp3_detail", 0);
 
-        glowMaterial = createMaterial("glow", "VertexLitGeneric", 
+        glowMaterial = createMaterial("glow", "VertexLitGeneric",
         R"#("VertexLitGeneric" {
             "$additive" "1"
             "$envmap" "models/effects/cube_white"
@@ -41,7 +41,7 @@ void createMaterials() {
             "$alpha" "0.8"
         })#");
 
-        oilMaterial = createMaterial("pearlescent", "VertexLitGeneric", 
+        oilMaterial = createMaterial("pearlescent", "VertexLitGeneric",
         R"#("VertexLitGeneric"
         {
             "$basetexture" "vgui/white_additive"
@@ -109,6 +109,14 @@ void chamPlayer(void* thisptr, void* ctx, const DrawModelState_t &state, const M
                                 for (Features::Backtrack::BackTrackTick tick : Features::Backtrack::backtrackTicks) {
                                     if (tick.tickCount % 2 == 0) { // only draw every other tick to reduce lag
                                         if (tick.players.find(p->index()) != tick.players.end()) {
+                                            // Check for velocity and origin diff so we don't stop
+                                            // drawing if the player walks back and forth
+                                            // Also checking for jumping as a fix for more oddities
+                                            if ((tick.players.at(p->index()).playerHeadPos.Length() - p->getBonePos(8).Length() < 0.2f) &&
+                                                    tick.players.at(p->index()).playerVelocity < 0.1f &&
+                                                    tick.players.at(p->index()).playerFlags & (1 << 0)) {
+                                                return;
+                                            }
                                             cham(thisptr, ctx, state, pInfo, tick.players.at(p->index()).boneMatrix, CONFIGCOL("Visuals>Players>Enemies>Chams>Backtrack Color"), CONFIGINT("Visuals>Players>Enemies>Chams>Backtrack Material"), false);
                                         }
                                     }
@@ -117,6 +125,14 @@ void chamPlayer(void* thisptr, void* ctx, const DrawModelState_t &state, const M
                             else {
                                 Features::Backtrack::BackTrackTick tick = Features::Backtrack::backtrackTicks.at(Features::Backtrack::backtrackTicks.size()-1);
                                 if (tick.players.find(p->index()) != tick.players.end()) {
+                                    // Check for velocity and origin diff so we don't stop
+                                    // drawing if the player walks back and forth
+                                    // Also checking for jumping as a fix for more oddities
+                                    if ((tick.players.at(p->index()).playerHeadPos.Length() - p->getBonePos(8).Length() < 0.2f) &&
+                                            tick.players.at(p->index()).playerVelocity < 0.1f &&
+                                            tick.players.at(p->index()).playerFlags & (1 << 0)) {
+                                        return;
+                                    }
                                     cham(thisptr, ctx, state, pInfo, tick.players.at(p->index()).boneMatrix, CONFIGCOL("Visuals>Players>Enemies>Chams>Backtrack Color"), CONFIGINT("Visuals>Players>Enemies>Chams>Backtrack Material"), false);
                                 }
                             }
@@ -192,7 +208,7 @@ void Features::Chams::drawModelExecute(void* thisptr, void* ctx, const DrawModel
         else {
             chamWeapon(thisptr, ctx, state, pInfo, pCustomBoneToWorld);
         }
-    } 
+    }
     else if (strstr(modelName, "models/weapons/v_")) {
         chamWeapon(thisptr, ctx, state, pInfo, pCustomBoneToWorld);
     }

--- a/src/core/features/features.hpp
+++ b/src/core/features/features.hpp
@@ -37,6 +37,9 @@ namespace Features {
         struct BacktrackPlayer {
             matrix3x4_t boneMatrix[128];
             int playerIndex;
+            int playerFlags;
+            float playerVelocity;
+            Vector playerHeadPos;
         };
 
         struct BackTrackTick {
@@ -121,7 +124,7 @@ namespace Features {
     }
     namespace RagdollGravity {
         void frameStageNotify(FrameStage frame);
-    } 
+    }
     namespace NoVisualRecoil {
         void frameStageNotify(FrameStage frame);
     }


### PR DESCRIPTION
This fixes the backtrack chams rendering when a player is standing still. This time it is done better. I am checking for a difference in head origin, and velocity, and if they are jumping.

It is important that we check for velocity and origin. If the player is stutter stepping the origin difference will be 0 at times while they are still moving. Checking for if they are moving AND the difference isn't 0 prevents this issue. The jumping check is to fix an odd issue where the chams only render when the player is falling if standing still.