### PR TITLE
Add unhooking for GetViewmodelFOV

### DIFF
--- a/src/core/hooks/getviewmodelfov.cpp
+++ b/src/core/hooks/getviewmodelfov.cpp
@@ -3,13 +3,11 @@
 #include "../features/features.hpp"
 
 float Hooks::GetViewmodelFOV::hook(void* thisptr) {
-    float fov = original(thisptr);
-
     if (CONFIGINT("Visuals>World>World>Viewmodel FOV") != 0) {
         if (Globals::localPlayer && Globals::localPlayer->health() > 0) {
-            fov = CONFIGINT("Visuals>World>World>Viewmodel FOV");
+            return CONFIGINT("Visuals>World>World>Viewmodel FOV");
         }
     }
 
-    return fov;
+    return original(thisptr);
 }

--- a/src/core/hooks/hooks.cpp
+++ b/src/core/hooks/hooks.cpp
@@ -83,6 +83,9 @@ bool Hooks::unload() {
     Log::log(LOG, " Unhooking OverrideView...");
     VMT::hook(Interfaces::clientMode, (void*)OverrideView::original, 19);
 
+    Log::log(LOG, " Unhooking GetViewmodelFOV...");
+    VMT::hook(Interfaces::clientMode, (void*)GetViewmodelFOV::original, 36);
+
     delete eventListener;
 
     Log::log(LOG, "Unloaded hooks!");


### PR DESCRIPTION
I forgot to unhook GetViewmodelFOV on unload. This would cause a crash while unloading. It is fixed here