### PR TITLE
Fixed jumping off ladders with bhop enabled

### DIFF
--- a/src/core/features/autohop.cpp
+++ b/src/core/features/autohop.cpp
@@ -3,8 +3,8 @@
 void Features::AutoHop::createMove(CUserCmd* cmd) {
     if (Globals::localPlayer) {
         if (CONFIGBOOL("Misc>Misc>Movement>Auto Hop")) {
+            if (Globals::localPlayer->moveType() == 9) return;
             if (CONFIGBOOL("Misc>Misc>Movement>Humanised Bhop")) {
-                if (Globals::localPlayer->moveType() != 9) {
                 // https://www.unknowncheats.me/forum/counterstrike-global-offensive/333797-humanised-bhop.html
                     static int hopsRestricted = 0;
                     static int hopsHit = 0;
@@ -12,9 +12,9 @@ void Features::AutoHop::createMove(CUserCmd* cmd) {
                         cmd->buttons &= ~(1<<1);
                         hopsRestricted = 0;
                     }
-                    else if ((rand() % 100 > CONFIGINT("Misc>Misc>Movement>Bhop Hitchance") && 
-                            hopsRestricted < CONFIGINT("Misc>Misc>Movement>Bhop Max Misses")) || 
-                            (CONFIGINT("Misc>Misc>Movement>Bhop Max Hops Hit") > 0 && 
+                    else if ((rand() % 100 > CONFIGINT("Misc>Misc>Movement>Bhop Hitchance") &&
+                            hopsRestricted < CONFIGINT("Misc>Misc>Movement>Bhop Max Misses")) ||
+                            (CONFIGINT("Misc>Misc>Movement>Bhop Max Hops Hit") > 0 &&
                             hopsHit > CONFIGINT("Misc>Misc>Movement>Bhop Max Hops Hit"))) {
                         cmd->buttons &= ~(1<<1);
                         hopsRestricted++;
@@ -23,11 +23,10 @@ void Features::AutoHop::createMove(CUserCmd* cmd) {
                     else {
                         hopsHit++;
                     }
-                }
             }
             else {
-                if (!(Globals::localPlayer->flags() & (1<<0))) { // need to make macro for FL_* 
-                    cmd->buttons &= ~(1<<1); // need to make macro for IN_* 
+                if (!(Globals::localPlayer->flags() & (1<<0))) { // need to make macro for FL_*
+                    cmd->buttons &= ~(1<<1); // need to make macro for IN_*
                 }
             }
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please consider not. -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of features to the cheat at the end of README.md in the root of this repository, please add your changes there if appropriate -->

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
Changed the location of the if statement that checks if player is on ladder, previously this was only in the part of humanized bhop
## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
Jumping off ladders is now possible with autobhop and without having to enable humanized bhop
