### PR TITLE
Fix warnings from unitialized variables

### DIFF
--- a/src/core/features/antiaim.cpp
+++ b/src/core/features/antiaim.cpp
@@ -6,7 +6,7 @@ bool updatingLby() {
     AnimState* animState = Globals::localPlayer->animState();
     float curtime = Globals::localPlayer->tickbase() * Interfaces::globals->interval_per_tick;
     static float lbyTime;
-     
+
     if (animState->verticalVelocity > 0.1f || fabs(animState->horizontalVelocity) > 100.0f) {
         lbyTime = curtime + 0.22f;
         return false;
@@ -29,14 +29,14 @@ void Features::AntiAim::createMove(CUserCmd* cmd) {
                         if (!((cmd->buttons & (1 << 0)) || (cmd->buttons & (1 << 5)))) {
                             if (CONFIGINT("Rage>AntiAim>Type")) {
                                 // TODO: for some reason it refuses to desync when looking forward???!?!?
-                                
+
                                 cmd->viewangles.x = CONFIGINT("Rage>AntiAim>Pitch");
 
-                                int real;
-                                int fake;
+                                int real = 0;
+                                int fake = 0;
 
                                 switch (CONFIGINT("Rage>AntiAim>Type")) {
-                                    case 1: { // Static 
+                                    case 1: { // Static
                                         real = cmd->viewangles.y + CONFIGINT("Rage>AntiAim>Offset");
                                         fake = CONFIGINT("Rage>AntiAim>Static>Desync");
                                         break;
@@ -53,13 +53,13 @@ void Features::AntiAim::createMove(CUserCmd* cmd) {
                                         fake = jitterAmt;
                                         break;
                                     }
-                                    case 4: { // Real Jitter 
+                                    case 4: { // Real Jitter
                                         int jitterAmt = (((cmd->tick_count % CONFIGINT("Rage>AntiAim>Real Jitter>Jitter Delay")) < CONFIGINT("Rage>AntiAim>Real Jitter>Jitter Delay") / 2) ? 1 : -1) * (CONFIGINT("Rage>AntiAim>Real Jitter>Jitter Amount") - (CONFIGINT("Rage>AntiAim>Real Jitter>Jitter Amount")/2));
                                         real = cmd->viewangles.y + CONFIGINT("Rage>AntiAim>Offset") + jitterAmt;
                                         fake = CONFIGINT("Rage>AntiAim>Static>Desync") - jitterAmt;
                                         break;
                                     }
-                                    case 5: { // Spin 
+                                    case 5: { // Spin
                                         real = cmd->viewangles.y + (cmd->tick_count * CONFIGINT("Rage>AntiAim>Offset"));
                                         fake = CONFIGINT("Rage>AntiAim>Spin>Desync");
                                         break;

--- a/src/core/features/legitbot.cpp
+++ b/src/core/features/legitbot.cpp
@@ -64,7 +64,7 @@ void Features::LegitBot::createMove(CUserCmd* cmd) {
             }
 
             float closestDelta = FLT_MAX;
-            QAngle angleToClosestBone;
+            QAngle angleToClosestBone = QAngle(0, 0, 0);
 
             // NOTE: We should really be using returns more, it cleans up
             //       the code a good bit, and makes it easier to understand

--- a/src/core/features/ragebot.cpp
+++ b/src/core/features/ragebot.cpp
@@ -8,7 +8,7 @@ void Features::RageBot::createMove(CUserCmd* cmd) {
             float FOV = CONFIGINT("Rage>RageBot>Default>FOV")/10.f;
 
             float closestDelta = FLT_MAX;
-            QAngle angleToClosestPlayer;
+            QAngle angleToClosestPlayer = QAngle(0, 0, 0);
 
             // Enumerate over players and get angle to the closest player to crosshair
             for (int i = 1; i < Interfaces::globals->maxClients; i++) {
@@ -19,7 +19,7 @@ void Features::RageBot::createMove(CUserCmd* cmd) {
                         if (p->getAnythingBones(boneMatrix)) {
                             Vector localPlayerEyePos = Globals::localPlayer->eyePos();
                             Vector targetBonePos = p->getBonePos(8);
-                            
+
                             //TODO check which bone would be exposed sooner with engine prediction and which would do more damage.
                             if(CONFIGBOOL("Rage>RageBot>Default>ForceBaim")) {
                                 if(p->health() <= CONFIGINT("Rage>RageBot>Default>ForceBaimValue")) {


### PR DESCRIPTION
Gives a value when initializing a few variables. This gets rid of some annoying warnings when compiling.