### PR TITLE
Add time to the overlay

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -14,3 +14,4 @@ nigma1337
 vampur
 DENZIL
 Enron
+Everly (everlyy)

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Monero:
  - JumpBug
  - EdgeBug
  - Edge Jump
+ - Block Bot
 
 
 ## How to use

--- a/src/core/features/blockbot.cpp
+++ b/src/core/features/blockbot.cpp
@@ -1,0 +1,47 @@
+#include "../../includes.hpp"
+#include "features.hpp"
+
+// https://github.com/LWSS/Fuzion/blob/master/src/Hacks/autoblock.cpp
+void Features::BlockBot::createMove(CUserCmd* cmd) {
+	if (!CONFIGBOOL("Misc>Misc>Misc>Block Bot") || !Menu::CustomWidgets::isKeyDown(CONFIGINT("Misc>Misc>Misc>Block Bot Key")))
+		return;
+
+
+	if (!Globals::localPlayer || Globals::localPlayer->health() <= 0)
+		return;
+
+	float bestDist = 250.0f;
+	int index = -1;
+
+	for (int i = 0; i < Interfaces::globals->maxClients; i++) {
+		Player* player = (Player*)Interfaces::entityList->GetClientEntity(i);
+		
+		if(!player || player->health() <= 0 || player->dormant() || player == Globals::localPlayer)
+			continue;
+
+		float dist = Globals::localPlayer->origin().DistTo(player->origin());
+
+		if(dist < bestDist) {
+			bestDist = dist;
+			index = i;
+		}		
+	}
+
+	// No player was found to block
+	if (index == -1) 
+		return;
+
+	Player* target = (Player*)Interfaces::entityList->GetClientEntity(index);
+
+	if (!target)
+		return;
+
+	QAngle angles = calcAngle(Globals::localPlayer->origin(), target->origin());
+	angles.y -= Globals::localPlayer->viewAngles()->y;
+	normalizeAngles(angles);
+	
+	if (angles.y < 0.0f)
+		cmd->sidemove = 250.0f;
+	else if (angles.y > 0)
+		cmd->sidemove = -250.0f;		
+}

--- a/src/core/features/features.hpp
+++ b/src/core/features/features.hpp
@@ -141,4 +141,7 @@ namespace Features {
         void edgeBugPredictor(CUserCmd* cmd);
         void draw();
     }
+    namespace BlockBot {
+    	void createMove(CUserCmd* cmd);
+    }
 }

--- a/src/core/features/legitbot.cpp
+++ b/src/core/features/legitbot.cpp
@@ -12,6 +12,7 @@ void Features::LegitBot::createMove(CUserCmd* cmd) {
             float FOV = CONFIGINT("Legit>LegitBot>Default>FOV")/10.f;
             bool recoilCompensation = CONFIGBOOL("Legit>LegitBot>Default>Recoil Compensation");
             bool aimWhileBlind = CONFIGBOOL("Legit>LegitBot>Default>Aim While Blind");
+            bool aimAtTeammates = CONFIGBOOL("Legit>LegitBot>Default>Aim At Teammates");
 
             if ((std::find(std::begin(pistols), std::end(pistols), weapon->itemIndex() & 0xFFF) != std::end(pistols)) && CONFIGBOOL("Legit>LegitBot>Pistol>Override")) {
                 hitboxes = CONFIGINT("Legit>LegitBot>Pistol>Hitboxes");
@@ -19,6 +20,7 @@ void Features::LegitBot::createMove(CUserCmd* cmd) {
                 FOV = CONFIGINT("Legit>LegitBot>Pistol>FOV")/10.f;
                 recoilCompensation = false;
                 aimWhileBlind = CONFIGBOOL("Legit>LegitBot>Pistol>Aim While Blind");
+                aimAtTeammates = CONFIGBOOL("Legit>LegitBot>Pistol>Aim At Teammates");
             }
             else if ((std::find(std::begin(heavyPistols), std::end(heavyPistols), weapon->itemIndex() & 0xFFF) != std::end(heavyPistols)) && CONFIGBOOL("Legit>LegitBot>Heavy Pistol>Override")) {
                 hitboxes = CONFIGINT("Legit>LegitBot>Heavy Pistol>Hitboxes");
@@ -26,6 +28,7 @@ void Features::LegitBot::createMove(CUserCmd* cmd) {
                 FOV = CONFIGINT("Legit>LegitBot>Heavy Pistol>FOV")/10.f;
                 recoilCompensation = false;
                 aimWhileBlind = CONFIGBOOL("Legit>LegitBot>Heavy Pistol>Aim While Blind");
+                aimAtTeammates = CONFIGBOOL("Legit>LegitBot>Heavy Pistol>Aim At Teammates");
             }
             else if ((std::find(std::begin(rifles), std::end(rifles), weapon->itemIndex() & 0xFFF) != std::end(rifles)) && CONFIGBOOL("Legit>LegitBot>Rifle>Override")) {
                 hitboxes = CONFIGINT("Legit>LegitBot>Rifle>Hitboxes");
@@ -33,6 +36,7 @@ void Features::LegitBot::createMove(CUserCmd* cmd) {
                 FOV = CONFIGINT("Legit>LegitBot>Rifle>FOV")/10.f;
                 recoilCompensation = CONFIGINT("Legit>LegitBot>Rifle>Recoil Compensation");
                 aimWhileBlind = CONFIGBOOL("Legit>LegitBot>Rifle>Aim While Blind");
+                aimAtTeammates = CONFIGBOOL("Legit>LegitBot>Rifle>Aim At Teammates");
             }
             else if ((std::find(std::begin(smgs), std::end(smgs), weapon->itemIndex() & 0xFFF) != std::end(smgs)) && CONFIGBOOL("Legit>LegitBot>SMG>Override")) {
                 hitboxes = CONFIGINT("Legit>LegitBot>SMG>Hitboxes");
@@ -40,6 +44,7 @@ void Features::LegitBot::createMove(CUserCmd* cmd) {
                 FOV = CONFIGINT("Legit>LegitBot>SMG>FOV")/10.f;
                 recoilCompensation = CONFIGINT("Legit>LegitBot>SMG>Recoil Compensation");
                 aimWhileBlind = CONFIGBOOL("Legit>LegitBot>SMG>Aim While Blind");
+                aimAtTeammates = CONFIGBOOL("Legit>LegitBot>SMG>Aim At Teammates");
             }
             else if (((weapon->itemIndex() & 0xFFF) == WEAPON_SSG08) && CONFIGBOOL("Legit>LegitBot>Scout>Override")) {
                 hitboxes = CONFIGINT("Legit>LegitBot>Scout>Hitboxes");
@@ -47,6 +52,7 @@ void Features::LegitBot::createMove(CUserCmd* cmd) {
                 FOV = CONFIGINT("Legit>LegitBot>Scout>FOV")/10.f;
                 recoilCompensation = false;
                 aimWhileBlind = CONFIGBOOL("Legit>LegitBot>Scout>Aim While Blind");
+                aimAtTeammates = CONFIGBOOL("Legit>LegitBot>Scout>Aim At Teammates");
             }
             else if (((weapon->itemIndex() & 0xFFF) == WEAPON_AWP) && CONFIGBOOL("Legit>LegitBot>AWP>Override")) {
                 hitboxes = CONFIGINT("Legit>LegitBot>AWP>Hitboxes");
@@ -54,6 +60,7 @@ void Features::LegitBot::createMove(CUserCmd* cmd) {
                 FOV = CONFIGINT("Legit>LegitBot>AWP>FOV")/10.f;
                 recoilCompensation = false;
                 aimWhileBlind = CONFIGBOOL("Legit>LegitBot>AWP>Aim While Blind");
+                aimAtTeammates = CONFIGBOOL("Legit>LegitBot>AWP>Aim At Teammates");
             }
             else if ((std::find(std::begin(heavyWeapons), std::end(heavyWeapons), weapon->itemIndex() & 0xFFF) != std::end(heavyWeapons)) && CONFIGBOOL("Legit>LegitBot>Heavy>Override")) {
                 hitboxes = CONFIGINT("Legit>LegitBot>Heavy>Hitboxes");
@@ -61,6 +68,7 @@ void Features::LegitBot::createMove(CUserCmd* cmd) {
                 FOV = CONFIGINT("Legit>LegitBot>Heavy>FOV")/10.f;
                 recoilCompensation = CONFIGINT("Legit>LegitBot>Heavy>Recoil Compensation");
                 aimWhileBlind = CONFIGBOOL("Legit>LegitBot>Heavy>Aim While Blind");
+                aimAtTeammates = CONFIGBOOL("Legit>LegitBot>Heavy>Aim At Teammates");
             }
 
             float closestDelta = FLT_MAX;
@@ -74,7 +82,11 @@ void Features::LegitBot::createMove(CUserCmd* cmd) {
             for (int i = 1; i < Interfaces::globals->maxClients; i++) {
                 Player* p = (Player*)Interfaces::entityList->GetClientEntity(i);
                 if (p && p != Globals::localPlayer) {
-                    if (p->health() > 0 && !p->dormant() && p->isEnemy() && p->visible()) {
+                	bool isTeammate = !p->isEnemy();
+                	if(isTeammate && !aimAtTeammates)
+                		continue;
+                				
+                    if (p->health() > 0 && !p->dormant() && p->visible()) {
 
                         // TODO: There is probably a better way to do this,
                         //       but when I tried making a timer with curtime

--- a/src/core/features/movement.cpp
+++ b/src/core/features/movement.cpp
@@ -117,7 +117,7 @@ void Features::Movement::edgeBugPredictor(CUserCmd *cmd) {
 
     int nCmdsPred = Interfaces::prediction->Split->nCommandsPredicted;
 
-    int predictAmount = CONFIGINT("Misc>Misc>Movement>EdgeBug Predict Amount"); // TODO: make amount configurable
+    int predictAmount = CONFIGINT("Misc>Misc>Movement>EdgeBug Predict Amount");
     for (int t = 0; t < 4; t++) {
         Features::Prediction::restoreEntityToPredictedFrame(nCmdsPred - 1);
 

--- a/src/core/features/movement.cpp
+++ b/src/core/features/movement.cpp
@@ -117,7 +117,7 @@ void Features::Movement::edgeBugPredictor(CUserCmd *cmd) {
 
     int nCmdsPred = Interfaces::prediction->Split->nCommandsPredicted;
 
-    int predictAmount = 128; // TODO: make amount configurable
+    int predictAmount = CONFIGINT("Misc>Misc>Movement>EdgeBug Predict Amount"); // TODO: make amount configurable
     for (int t = 0; t < 4; t++) {
         Features::Prediction::restoreEntityToPredictedFrame(nCmdsPred - 1);
 

--- a/src/core/features/triggerbot.cpp
+++ b/src/core/features/triggerbot.cpp
@@ -36,7 +36,13 @@ void Features::Triggerbot::createMove(CUserCmd* cmd) {
                 endPos = Globals::localPlayer->eyePos() + (endPos*4096);
 
                 Entity* ent = findPlayerThatRayHits(Globals::localPlayer->eyePos(), endPos, &traceToPlayer);
-                if (ent && ent->clientClass()->m_ClassID == CCSPlayer && !ent->dormant() && ((Player*)ent)->isEnemy()) {
+
+				bool triggerOnTeammates = CONFIGBOOL("Legit>Triggerbot>Trigger On Teammates");
+				bool isTeammate = !((Player*)ent)->isEnemy();
+				if(isTeammate && !triggerOnTeammates)
+					return;
+                
+                if (ent && ent->clientClass()->m_ClassID == CCSPlayer && !ent->dormant()) {
                     switch (traceToPlayer.hitgroup) {
                         case HITGROUP_HEAD:
                             headHitchance++;

--- a/src/core/hooks/createmove.cpp
+++ b/src/core/hooks/createmove.cpp
@@ -3,8 +3,6 @@
 #include <algorithm>
 #include <cstdint>
 
-
-
 bool Hooks::CreateMove::hook(void* thisptr, float flInputSampleTime, CUserCmd* cmd) {
     original(thisptr, flInputSampleTime, cmd);
     if (cmd->tick_count != 0) {
@@ -49,6 +47,7 @@ bool Hooks::CreateMove::hook(void* thisptr, float flInputSampleTime, CUserCmd* c
 
         auto view_backup = cmd->viewangles;
         Features::Movement::edgeBugPredictor(cmd);
+        Features::BlockBot::createMove(cmd);
         startMovementFix(cmd);
         cmd->viewangles = view_backup;
         endMovementFix(cmd);

--- a/src/core/menu/config.hpp
+++ b/src/core/menu/config.hpp
@@ -145,6 +145,7 @@ namespace Config {
             // Triggerbot {
                 CONFIGITEM("Legit>Triggerbot>Key", 0),
                 CONFIGITEM("Legit>Triggerbot>Triggerbot", false),
+                CONFIGITEM("Legit>Triggerbot>Trigger On Teammates", false),
                 CONFIGITEM("Legit>Triggerbot>Head Hitchance", 0),
                 CONFIGITEM("Legit>Triggerbot>Body Hitchance", 0),
             // }

--- a/src/core/menu/config.hpp
+++ b/src/core/menu/config.hpp
@@ -73,6 +73,7 @@ namespace Config {
                     CONFIGITEM("Legit>LegitBot>Default>Smoothing", 0),
                     CONFIGITEM("Legit>LegitBot>Default>Recoil Compensation", false),
                     CONFIGITEM("Legit>LegitBot>Default>Aim While Blind", false),
+                    CONFIGITEM("Legit>LegitBot>Default>Aim At Teammates", false),
                 //}
                 // Pistol {
                     CONFIGITEM("Legit>LegitBot>Pistol>Hitboxes", 1),
@@ -80,6 +81,7 @@ namespace Config {
                     CONFIGITEM("Legit>LegitBot>Pistol>FOV", 0),
                     CONFIGITEM("Legit>LegitBot>Pistol>Smoothing", 0),
                     CONFIGITEM("Legit>LegitBot>Pistol>Aim While Blind", false),
+                    CONFIGITEM("Legit>LegitBot>Pistol>Aim At Teammates", false),
                 //}
                 // Heavy Pistol {
                     CONFIGITEM("Legit>LegitBot>Heavy Pistol>Hitboxes", 1),
@@ -87,6 +89,7 @@ namespace Config {
                     CONFIGITEM("Legit>LegitBot>Heavy Pistol>FOV", 0),
                     CONFIGITEM("Legit>LegitBot>Heavy Pistol>Smoothing", 0),
                     CONFIGITEM("Legit>LegitBot>Heavy Pistol>Aim While Blind", false),
+                    CONFIGITEM("Legit>LegitBot>Heavy Pistol>Aim At Teammates", false),
                 //}
                 // Rifle {
                     CONFIGITEM("Legit>LegitBot>Rifle>Hitboxes", 1),
@@ -95,6 +98,7 @@ namespace Config {
                     CONFIGITEM("Legit>LegitBot>Rifle>Smoothing", 0),
                     CONFIGITEM("Legit>LegitBot>Rifle>Recoil Compensation", false),
                     CONFIGITEM("Legit>LegitBot>Rifle>Aim While Blind", false),
+                    CONFIGITEM("Legit>LegitBot>Rifle>Aim At Teammates", false),
                 //}
                 // SMG {
                     CONFIGITEM("Legit>LegitBot>SMG>Hitboxes", 1),
@@ -103,6 +107,7 @@ namespace Config {
                     CONFIGITEM("Legit>LegitBot>SMG>Smoothing", 0),
                     CONFIGITEM("Legit>LegitBot>SMG>Recoil Compensation", false),
                     CONFIGITEM("Legit>LegitBot>SMG>Aim While Blind", false),
+                    CONFIGITEM("Legit>LegitBot>SMG>Aim At Teammates", false),
                 //}
                 // Scout {
                     CONFIGITEM("Legit>LegitBot>Scout>Hitboxes", 1),
@@ -110,6 +115,7 @@ namespace Config {
                     CONFIGITEM("Legit>LegitBot>Scout>FOV", 0),
                     CONFIGITEM("Legit>LegitBot>Scout>Smoothing", 0),
                     CONFIGITEM("Legit>LegitBot>Scout>Aim While Blind", false),
+                    CONFIGITEM("Legit>LegitBot>Scout>Aim At Teammates", false),
                 //}
                 // AWP {
                     CONFIGITEM("Legit>LegitBot>AWP>Hitboxes", 1),
@@ -117,6 +123,7 @@ namespace Config {
                     CONFIGITEM("Legit>LegitBot>AWP>FOV", 0),
                     CONFIGITEM("Legit>LegitBot>AWP>Smoothing", 0),
                     CONFIGITEM("Legit>LegitBot>AWP>Aim While Blind", false),
+                    CONFIGITEM("Legit>LegitBot>AWP>Aim At Teammates", false),
                 //}
                 // Heavy {
                     CONFIGITEM("Legit>LegitBot>Heavy>Hitboxes", 1),
@@ -125,6 +132,7 @@ namespace Config {
                     CONFIGITEM("Legit>LegitBot>Heavy>Smoothing", 0),
                     CONFIGITEM("Legit>LegitBot>Heavy>Recoil Compensation", false),
                     CONFIGITEM("Legit>LegitBot>Heavy>Aim While Blind", false),
+                    CONFIGITEM("Legit>LegitBot>Heavy>Aim At Teammates", false),
                 //}
             // }
 

--- a/src/core/menu/config.hpp
+++ b/src/core/menu/config.hpp
@@ -368,6 +368,8 @@ namespace Config {
             CONFIGITEM("Misc>Misc>Misc>Use Spam Key", 0),
             CONFIGITEM("Misc>Misc>Misc>Disable Setting Cvars", false),
             CONFIGITEM("Misc>Misc>Misc>Disable Post Processing", false),
+            CONFIGITEM("Misc>Misc>Misc>Block Bot", false),
+            CONFIGITEM("Misc>Misc>Misc>Block Bot Key", 0),
 
             CONFIGITEM("Misc>Skins>Skins>PaintKit", 0),
             CONFIGITEM("Misc>Skins>Skins>Wear", 0),

--- a/src/core/menu/config.hpp
+++ b/src/core/menu/config.hpp
@@ -341,6 +341,7 @@ namespace Config {
             CONFIGITEM("Misc>Misc>Movement>JumpBug", false),
             CONFIGITEM("Misc>Misc>Movement>JumpBug Key", 0),
             CONFIGITEM("Misc>Misc>Movement>EdgeBug", false),
+            CONFIGITEM("Misc>Misc>Movement>EdgeBug Predict Amount", 128),
             CONFIGITEM("Misc>Misc>Movement>EdgeBug Key", 0),
             CONFIGITEM("Misc>Misc>Movement>Fast Duck", false),
 

--- a/src/core/menu/overlay.cpp
+++ b/src/core/menu/overlay.cpp
@@ -2,6 +2,7 @@
 #include <cstring>
 #include <unistd.h>
 #include <pwd.h>
+#include <ctime>
 
 // p100 flex ur distro
 char distro[32];
@@ -28,8 +29,14 @@ void Menu::drawOverlay(ImDrawList* drawList) {
     gethostname(hostname, 64);
     Globals::drawList = drawList;
     if(!CONFIGBOOL("Misc>Misc>Misc>Disable Watermark")) {
-        char watermarkText[64];
-        sprintf(watermarkText, "gamesneeze (%s - %s@%s) | %.1f FPS | %i ms", distro, getpwuid(getuid())->pw_name, hostname, ImGui::GetIO().Framerate, (Interfaces::engine->IsInGame() && playerResource) ? playerResource->GetPing(Interfaces::engine->GetLocalPlayer()) : 0);
+        char watermarkText[128];
+        time_t currentTime;
+        tm* currentTm;
+        char timeStr[12];
+        time(&currentTime);
+        currentTm = localtime(&currentTime);
+        strftime(timeStr, 12, "%T", currentTm);
+        sprintf(watermarkText, "gamesneeze (%s - %s@%s) | %s | %.1f FPS | %i ms", distro, getpwuid(getuid())->pw_name, hostname, timeStr, ImGui::GetIO().Framerate, (Interfaces::engine->IsInGame() && playerResource) ? playerResource->GetPing(Interfaces::engine->GetLocalPlayer()) : 0);
         // Hacky way to do black shadow but it works
         Globals::drawList->AddText(ImVec2(4, 4), ImColor(0, 0, 0, 255), watermarkText);
         Globals::drawList->AddText(ImVec2(3, 3), ImColor(255, 255, 255, 255), watermarkText);

--- a/src/core/menu/tabs/legit.cpp
+++ b/src/core/menu/tabs/legit.cpp
@@ -36,7 +36,7 @@ void hitboxSelectBox(const char* configVarName) {
 }
 
 void Menu::drawLegitTab() {
-    ImGui::BeginChild("LegitBot", ImVec2(ImGui::GetWindowContentRegionWidth() * 0.65f, 260), true); {
+    ImGui::BeginChild("LegitBot", ImVec2(ImGui::GetWindowContentRegionWidth() * 0.65f, 300), true); {
         ImGui::Text("LegitBot");
         ImGui::Separator();
         if (ImGui::BeginTabBar("Aim Weapons Tabbar")) {
@@ -165,7 +165,7 @@ void Menu::drawLegitTab() {
         ImGui::EndChild();
     }
     ImGui::SameLine();
-    ImGui::BeginChild("Triggerbot", ImVec2(0, 260), true); {
+    ImGui::BeginChild("Triggerbot", ImVec2(0, 300), true); {
         ImGui::Text("Triggerbot");
         ImGui::Separator();
         if (CONFIGBOOL("Legit>Triggerbot>Triggerbot")) {

--- a/src/core/menu/tabs/legit.cpp
+++ b/src/core/menu/tabs/legit.cpp
@@ -175,6 +175,7 @@ void Menu::drawLegitTab() {
         }
         ImGui::Checkbox("Triggerbot", &CONFIGBOOL("Legit>Triggerbot>Triggerbot"));
         if (CONFIGBOOL("Legit>Triggerbot>Triggerbot")) {
+        	ImGui::Checkbox("Trigger On Teammates", &CONFIGBOOL("Legit>Triggerbot>Trigger On Teammates"));
             ImGui::Text("Head Hitchance");
             ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
             ImGui::SliderInt("##Head Hitchance", &CONFIGINT("Legit>Triggerbot>Head Hitchance"), 0, 100);

--- a/src/core/menu/tabs/legit.cpp
+++ b/src/core/menu/tabs/legit.cpp
@@ -54,6 +54,7 @@ void Menu::drawLegitTab() {
                 ImGui::SliderInt("##Smoothing", &CONFIGINT("Legit>LegitBot>Default>Smoothing"), 0, 100);
                 ImGui::Checkbox("Recoil Compensation", &CONFIGBOOL("Legit>LegitBot>Default>Recoil Compensation"));
                 ImGui::Checkbox("Aim While Blind", &CONFIGBOOL("Legit>LegitBot>Default>Aim While Blind"));
+                ImGui::Checkbox("Aim At Teammates", &CONFIGBOOL("Legit>LegitBot>Default>Aim At Teammates"));
 
 
                 ImGui::EndTabItem();
@@ -68,6 +69,7 @@ void Menu::drawLegitTab() {
                 ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
                 ImGui::SliderInt("##Smoothing", &CONFIGINT("Legit>LegitBot>Pistol>Smoothing"), 0, 100);
                 ImGui::Checkbox("Aim While Blind", &CONFIGBOOL("Legit>LegitBot>Pistol>Aim While Blind"));
+                ImGui::Checkbox("Aim At Teammates", &CONFIGBOOL("Legit>LegitBot>Pistol>Aim At Teammates"));
 
                 ImGui::EndTabItem();
             }
@@ -81,6 +83,7 @@ void Menu::drawLegitTab() {
                 ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
                 ImGui::SliderInt("##Smoothing", &CONFIGINT("Legit>LegitBot>Heavy Pistol>Smoothing"), 0, 100);
                 ImGui::Checkbox("Aim While Blind", &CONFIGBOOL("Legit>LegitBot>Heavy Pistol>Aim While Blind"));
+                ImGui::Checkbox("Aim At Teammates", &CONFIGBOOL("Legit>LegitBot>Heavy Pistol>Aim At Teammates"));
 
                 ImGui::EndTabItem();
             }
@@ -95,6 +98,7 @@ void Menu::drawLegitTab() {
                 ImGui::SliderInt("##Smoothing", &CONFIGINT("Legit>LegitBot>Rifle>Smoothing"), 0, 100);
                 ImGui::Checkbox("Recoil Compensation", &CONFIGBOOL("Legit>LegitBot>Rifle>Recoil Compensation"));
                 ImGui::Checkbox("Aim While Blind", &CONFIGBOOL("Legit>LegitBot>Rifle>Aim While Blind"));
+                ImGui::Checkbox("Aim At Teammates", &CONFIGBOOL("Legit>LegitBot>Rifle>Aim At Teammates"));
 
                 ImGui::EndTabItem();
             }
@@ -109,6 +113,7 @@ void Menu::drawLegitTab() {
                 ImGui::SliderInt("##Smoothing", &CONFIGINT("Legit>LegitBot>SMG>Smoothing"), 0, 100);
                 ImGui::Checkbox("Recoil Compensation", &CONFIGBOOL("Legit>LegitBot>SMG>Recoil Compensation"));
                 ImGui::Checkbox("Aim While Blind", &CONFIGBOOL("Legit>LegitBot>SMG>Aim While Blind"));
+                ImGui::Checkbox("Aim At Teammates", &CONFIGBOOL("Legit>LegitBot>SMG>Aim At Teammates"));
 
                 ImGui::EndTabItem();
             }
@@ -122,6 +127,7 @@ void Menu::drawLegitTab() {
                 ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
                 ImGui::SliderInt("##Smoothing", &CONFIGINT("Legit>LegitBot>Scout>Smoothing"), 0, 100);
                 ImGui::Checkbox("Aim While Blind", &CONFIGBOOL("Legit>LegitBot>Scout>Aim While Blind"));
+                ImGui::Checkbox("Aim At Teammates", &CONFIGBOOL("Legit>LegitBot>Scout>Aim At Teammates"));
 
                 ImGui::EndTabItem();
             }
@@ -135,6 +141,7 @@ void Menu::drawLegitTab() {
                 ImGui::SetNextItemWidth(ImGui::GetWindowContentRegionWidth());
                 ImGui::SliderInt("##Smoothing", &CONFIGINT("Legit>LegitBot>AWP>Smoothing"), 0, 100);
                 ImGui::Checkbox("Aim While Blind", &CONFIGBOOL("Legit>LegitBot>AWP>Aim While Blind"));
+                ImGui::Checkbox("Aim At Teammates", &CONFIGBOOL("Legit>LegitBot>AWP>Aim At Teammates"));
 
                 ImGui::EndTabItem();
             }
@@ -149,6 +156,7 @@ void Menu::drawLegitTab() {
                 ImGui::SliderInt("##Smoothing", &CONFIGINT("Legit>LegitBot>Heavy>Smoothing"), 0, 100);
                 ImGui::Checkbox("Recoil Compensation", &CONFIGBOOL("Legit>LegitBot>Heavy>Recoil Compensation"));
                 ImGui::Checkbox("Aim While Blind", &CONFIGBOOL("Legit>LegitBot>Heavy>Aim While Blind"));
+                ImGui::Checkbox("Aim At Teammates", &CONFIGBOOL("Legit>LegitBot>Heavy>Aim At Teammates"));
 
                 ImGui::EndTabItem();
             }

--- a/src/core/menu/tabs/misc.cpp
+++ b/src/core/menu/tabs/misc.cpp
@@ -37,6 +37,12 @@ void Menu::drawMiscTab() {
                 ImGui::Checkbox("Use Spam", &CONFIGBOOL("Misc>Misc>Misc>Use Spam"));
                 ImGui::Checkbox("Disable Setting Cvars", &CONFIGBOOL("Misc>Misc>Misc>Disable Setting Cvars"));
                 ImGui::Checkbox("Disable Post Processing", &CONFIGBOOL("Misc>Misc>Misc>Disable Post Processing"));
+                if (CONFIGBOOL("Misc>Misc>Misc>Block Bot")) {
+                	static bool toggled = false;
+                	Menu::CustomWidgets::drawKeyBinder("Key", &CONFIGINT("Misc>Misc>Misc>Block Bot Key"), &toggled);
+                	ImGui::SameLine();
+                }
+                ImGui::Checkbox("Block Bot", &CONFIGBOOL("Misc>Misc>Misc>Block Bot"));
                 ImGui::EndChild();
             }
 

--- a/src/core/menu/tabs/misc.cpp
+++ b/src/core/menu/tabs/misc.cpp
@@ -119,12 +119,13 @@ void Menu::drawMiscTab() {
                     ImGui::SameLine();
                 }
                 ImGui::Checkbox("JumpBug", &CONFIGBOOL("Misc>Misc>Movement>JumpBug"));
+                ImGui::Checkbox("EdgeBug", &CONFIGBOOL("Misc>Misc>Movement>EdgeBug"));
                 if (CONFIGBOOL("Misc>Misc>Movement>EdgeBug")) {
                     static bool toggled = false;
                     Menu::CustomWidgets::drawKeyBinder("Key", &CONFIGINT("Misc>Misc>Movement>EdgeBug Key"), &toggled);
                     ImGui::SameLine();
+                    ImGui::SliderInt("##EdgeBug Predict Amount", &CONFIGINT("Misc>Misc>Movement>EdgeBug Predict Amount"), 96, 228);
                 }
-                ImGui::Checkbox("EdgeBug", &CONFIGBOOL("Misc>Misc>Movement>EdgeBug"));
                 ImGui::Checkbox("Fast Duck", &CONFIGBOOL("Misc>Misc>Movement>Fast Duck"));
                 ImGui::SameLine();
                 ImGui::TextDisabled("?");


### PR DESCRIPTION
## Description:
This adds the time to the in-game overlay. This is useful if you don't want to go to your desktop to check the time while you're playing.

## Benefits of this PR and context:
It's useful if you're playing and you quickly want to look at the time without having to minimize your game.
