### PR TITLE
Add an option to disable netvars

### DIFF
--- a/src/core/features/esp.cpp
+++ b/src/core/features/esp.cpp
@@ -285,12 +285,12 @@ void Features::ESP::draw() {
                         }
 
                         else if (clientClass->m_ClassID == EClassIds::CFogController && CONFIGBOOL("Visuals>World>World>Override Fog")) {
-                            *((FogController*)ent)->enable_ptr() = true;
-                            *((FogController*)ent)->start_ptr() = (float)CONFIGINT("Visuals>World>World>Fog Start");
-                            *((FogController*)ent)->end_ptr() = (float)CONFIGINT("Visuals>World>World>Fog End");
-                            *((FogController*)ent)->maxDensity_ptr() = ((float)CONFIGINT("Visuals>World>World>Fog Density"))/1000;
-                            *((FogController*)ent)->farz_ptr() = (float)CONFIGINT("Visuals>World>World>Fog Farz");
-                            *((FogController*)ent)->colorPrimary_ptr() = ImGui::ColorConvertFloat4ToU32(CONFIGCOL("Visuals>World>World>Fog Color").Value);
+                            ((FogController*)ent)->enable_set(true);
+                            ((FogController*)ent)->start_set((float)CONFIGINT("Visuals>World>World>Fog Start"));
+                            ((FogController*)ent)->end_set((float)CONFIGINT("Visuals>World>World>Fog End"));
+                            ((FogController*)ent)->maxDensity_set(((float)CONFIGINT("Visuals>World>World>Fog Density"))/1000);
+                            ((FogController*)ent)->farz_set((float)CONFIGINT("Visuals>World>World>Fog Farz"));
+                            ((FogController*)ent)->colorPrimary_set(ImGui::ColorConvertFloat4ToU32(CONFIGCOL("Visuals>World>World>Fog Color").Value));
                         }
 
                         /* Debug ESP Everything*/

--- a/src/core/features/nightmode.cpp
+++ b/src/core/features/nightmode.cpp
@@ -1,10 +1,10 @@
 #include "features.hpp"
 
 void Features::Nightmode::onTonemapController(TonemapController* tonemapController) {
-    *tonemapController->useExposureMin_ptr() = CONFIGINT("Visuals>World>World>Nightmode") ? 1 : 0;
-    *tonemapController->useExposureMax_ptr() = CONFIGINT("Visuals>World>World>Nightmode") ? 1 : 0;
+    tonemapController->useExposureMin_set(CONFIGINT("Visuals>World>World>Nightmode") ? 1 : 0);
+    tonemapController->useExposureMax_set(CONFIGINT("Visuals>World>World>Nightmode") ? 1 : 0);
 
                                                         // Divide by 201 so then it never hits 0, as when it hits 0 it will be ignored
-    *tonemapController->exposureMin_ptr() = 0.5f - (CONFIGINT("Visuals>World>World>Nightmode") / 201.f);
-    *tonemapController->exposureMax_ptr() = 0.5f - (CONFIGINT("Visuals>World>World>Nightmode") / 201.f);
+    tonemapController->exposureMin_set(0.5f - (CONFIGINT("Visuals>World>World>Nightmode") / 201.f));
+    tonemapController->exposureMax_set(0.5f - (CONFIGINT("Visuals>World>World>Nightmode") / 201.f));
 }

--- a/src/core/features/noflash.cpp
+++ b/src/core/features/noflash.cpp
@@ -2,6 +2,6 @@
 
 void Features::NoFlash::frameStageNotify(FrameStage frame) {
     if(Interfaces::engine->IsInGame() && Globals::localPlayer) {
-        *Globals::localPlayer->maxFlashAlpha_ptr() = CONFIGBOOL("Visuals>World>World>No Flash") ? CONFIGINT("Visuals>World>World>No Flash Amount") : 255;
+        Globals::localPlayer->maxFlashAlpha_set(CONFIGBOOL("Visuals>World>World>No Flash") ? CONFIGINT("Visuals>World>World>No Flash Amount") : 255);
     }
 }

--- a/src/core/features/radar.cpp
+++ b/src/core/features/radar.cpp
@@ -2,6 +2,6 @@
 
 void Features::Radar::espPlayerLoop(Player* p) {
     if (!p->dormant() && CONFIGBOOL("Visuals>Players>Enemies>Radar") && ((Globals::localPlayer->health() == 0 && CONFIGBOOL("Visuals>Players>Enemies>Only When Dead")) || !CONFIGBOOL("Visuals>Players>Enemies>Only When Dead"))) { 
-        *p->spotted_ptr() = true;
+        p->spotted_set(true);
     }
 }

--- a/src/core/features/skinchanger.cpp
+++ b/src/core/features/skinchanger.cpp
@@ -24,11 +24,11 @@ void Features::SkinChanger::frameStageNotify(FrameStage frame) {
 
                 player_info_t info;
                 Interfaces::engine->GetPlayerInfo(Interfaces::engine->GetLocalPlayer(), &info);
-                *weapon->accountID_ptr() = info.xuid;
-                *weapon->itemIDHigh_ptr() = -1;
-                *weapon->paintKit_ptr() = paintkit;
-                *weapon->wear_ptr() = wear;
-                *weapon->statTrack_ptr() = statTrack;
+                weapon->accountID_set(info.xuid);
+                weapon->itemIDHigh_set(-1);
+                weapon->paintKit_set(paintkit);
+                weapon->wear_set(wear);
+                weapon->statTrack_set(statTrack);
             }
         } catch (std::out_of_range& e) {
             //Log::log(WARN, "itemDefinitionIndex %d not found!", ((Weapon*)ent)->itemIndex());

--- a/src/core/menu/config.hpp
+++ b/src/core/menu/config.hpp
@@ -356,7 +356,8 @@ namespace Config {
             CONFIGITEM("Misc>Misc>Misc>Chat Filter Bypass", false),
             CONFIGITEM("Misc>Misc>Misc>Use Spam", false),
             CONFIGITEM("Misc>Misc>Misc>Use Spam Key", 0),
-            CONFIGITEM("Misc>Misc>Misc>Disable Setting Cvars", false),
+            CONFIGITEM("Misc>Misc>Misc>Disable Setting Cvars", true),
+            CONFIGITEM("Misc>Misc>Misc>Disable Setting Netvars", true),
             CONFIGITEM("Misc>Misc>Misc>Disable Post Processing", false),
 
             CONFIGITEM("Misc>Skins>Skins>PaintKit", 0),

--- a/src/core/menu/tabs/misc.cpp
+++ b/src/core/menu/tabs/misc.cpp
@@ -36,6 +36,7 @@ void Menu::drawMiscTab() {
                 }
                 ImGui::Checkbox("Use Spam", &CONFIGBOOL("Misc>Misc>Misc>Use Spam"));
                 ImGui::Checkbox("Disable Setting Cvars", &CONFIGBOOL("Misc>Misc>Misc>Disable Setting Cvars"));
+                ImGui::Checkbox("Disable Setting Netvars", &CONFIGBOOL("Misc>Misc>Misc>Disable Setting Netvars"));
                 ImGui::Checkbox("Disable Post Processing", &CONFIGBOOL("Misc>Misc>Misc>Disable Post Processing"));
                 ImGui::EndChild();
             }

--- a/src/sdk/interfaces/globalvars.hpp
+++ b/src/sdk/interfaces/globalvars.hpp
@@ -16,7 +16,7 @@ public:
 	//
 	// On the client, this (along with tickcount) takes a different meaning based on what
 	// piece of code you're in:
-	// 
+	//table, prop, func, type
 	//   - While receiving network packets (like in PreDataUpdate/PostDataUpdate and proxies),
 	//     this is set to the SERVER TICKCOUNT for that packet. There is no interval between
 	//     the server ticks.

--- a/src/sdk/netvars.hpp
+++ b/src/sdk/netvars.hpp
@@ -111,4 +111,19 @@ namespace Offsets {
 }
 
 #define GETNETVAROFFSET(table, prop) Netvar::offsets.at({table, prop})
-#define NETVAR( table, prop, func, type ) type& func() {return *reinterpret_cast<type*>(uintptr_t(this) + GETNETVAROFFSET(table, prop));}; type* func##_ptr() {return reinterpret_cast<type*>(uintptr_t(this) + GETNETVAROFFSET(table, prop));}
+#define NETVAR(table, prop, func, type) type& func() {                                          \
+        return *reinterpret_cast<type*>(uintptr_t(this) + GETNETVAROFFSET(table, prop));        \
+    }                                                                                           \
+    void func##_set(type value) {                                                               \
+        if (!CONFIGBOOL("Misc>Misc>Misc>Disable Setting Netvars"))                              \
+            *(reinterpret_cast<type*>(uintptr_t(this) + GETNETVAROFFSET(table, prop))) = value; \
+    }                                                                                           \
+    type* func##_ptr() {                                                                        \
+        static bool warned = false;                                                             \
+        if (CONFIGBOOL("Misc>Misc>Misc>Disable Setting Netvars") && !warned) {                  \
+            warned = true;                                                                      \
+            std::cout << "Setting netvars is disabled, but i'm making a pointer to"             \
+              << prop "anyway, you better know what you're doing";                              \
+        }                                                                                       \
+        return reinterpret_cast<type*>(uintptr_t(this) + GETNETVAROFFSET(table, prop));         \
+    }


### PR DESCRIPTION
P vac bypass

Doesn't disable setting netvars entirely because rage sets angles and I cba to think of a way to restrict access to struct fields.