### PR TITLE
Use system gdb

### DIFF
--- a/toolbox.sh
+++ b/toolbox.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-gdb="$(dirname "$0")/gdb" # For using a gdb build such as the cathook one (The one included)
+gdb="gdb"
 libname="libgamemodeauto.so.0" # Pretend to be gamemode, change this to another lib that may be in /maps (if already using real gamemode, I'd suggest using libMangoHud.so)
 csgo_pid=$(pidof csgo_linux64)
 


### PR DESCRIPTION
The packaged gdb was broken by some kernel update so the cheat wouldn't inject (see #162). Using the system gdb seems fine though.